### PR TITLE
Fix UnicodeEncodeError on Windows in focused mode (--start/--end)

### DIFF
--- a/scripts/watch.py
+++ b/scripts/watch.py
@@ -15,6 +15,16 @@ from pathlib import Path
 SCRIPT_DIR = Path(__file__).parent.resolve()
 sys.path.insert(0, str(SCRIPT_DIR))
 
+# Windows consoles default to cp1252, which can't encode characters like the
+# "→" arrow used in the focused-mode (--start/--end) report line — that
+# crashed the whole run with UnicodeEncodeError. Force UTF-8 on our streams so
+# output never dies. No-op where already UTF-8 or where reconfigure is missing.
+for _stream in (sys.stdout, sys.stderr):
+    try:
+        _stream.reconfigure(encoding="utf-8")
+    except (AttributeError, ValueError):
+        pass
+
 from download import download, is_url  # noqa: E402
 from frames import (  # noqa: E402
     MAX_FPS, auto_fps, auto_fps_focus, extract, extract_scene_change,


### PR DESCRIPTION
## Problem

On **Windows**, any focused run (`--start` / `--end`) crashes with `UnicodeEncodeError` right after the download completes:

```
UnicodeEncodeError: 'charmap' codec can't encode character '→'
  in position 25: character maps to <undefined>
```

The cause: in focused mode, `watch.py` prints a `Focus range: <start> → <end>` line containing the `→` arrow (U+2192). Windows' `sys.stdout` defaults to the **cp1252** codec, which can't encode that character, so the whole run dies. Full-video runs are unaffected because they never print the arrow.

### Repro (Windows)
```
python scripts/watch.py "<youtube-url>" --start 11:00 --end 21:39
```
→ downloads, then crashes on the `Focus range` print (exit 1).

## Fix

Reconfigure `stdout`/`stderr` to UTF-8 at startup, guarded so it's a no-op where the stream is already UTF-8 or lacks `reconfigure()` (e.g. when output is redirected to a non-tty wrapper). This makes output robust to any non-cp1252 character, not just this one arrow.

```python
for _stream in (sys.stdout, sys.stderr):
    try:
        _stream.reconfigure(encoding="utf-8")
    except (AttributeError, ValueError):
        pass
```

## Testing

Verified on **Windows 11 / Python 3.13.14**:
- Before: `--start/--end` crashes with `UnicodeEncodeError`.
- After: stdout flips `cp1252 → utf-8`; a focused run (`--start 0:30 --end 1:00`) prints the `Focus range: 00:30 → 01:00` report line cleanly and exits 0 — with no `PYTHONUTF8`/`PYTHONIOENCODING` env vars set.
- Full-video runs unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)