### PR TITLE
v0.3.0: native-language transcripts, auto-classification, and sampling/pacing fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,51 @@
 
 All notable changes to `/watch` are documented here.
 
+## [0.3.0] — 2026-06-25
+
+A reliability + cost pass driven by a head-to-head review of `/watch` against a
+plain transcript-only approach on three real videos (two German talking heads,
+one English screencast). The review surfaced four concrete issues; all are
+fixed here. **No new dependencies** — still pure ffmpeg + yt-dlp + stdlib.
+
+### Fixed
+- **Non-English videos got no transcript.** `download.py` hardcoded
+  `--sub-langs en,en-US,en-GB,en-orig`, so a German (or any non-English) video
+  fell through to "no captions" even though YouTube had native auto-captions.
+  It now probes the video's native language (`yt-dlp --dump-json`) and requests
+  the native track first, reducing the regional tag (`de-DE`) to the actually
+  downloadable base/`-orig` tracks (`de`, `de-orig`), with English as fallback.
+  Override with `$WATCH_SUB_LANGS`. The model reads any language and answers in
+  the user's — no machine translation in the pipeline.
+- **Fast-cut intros starved the rest of the video.** Scene extraction capped
+  with `-frames:v max_frames` in a single pass, so a montage intro with 100+
+  cuts in the first 20s consumed the whole budget and the remaining minutes
+  were never sampled. Now two-pass: detect *all* cuts, then sample for even
+  coverage *in time* (bucketed), snapping each pick to a real scene boundary.
+- **Pacing median collapsed to ~0.04s.** Timestamp parsing (`metadata=print`)
+  mis-aligned with written frames and padded gaps with `0.0`, creating phantom
+  zero-length shots. Switched to `showinfo` parsing, plus `compute_pacing` now
+  dedups non-increasing timestamps and excludes sub-frame slivers from the
+  mean/median.
+- **Hook-microscope frames were extracted but never surfaced.** The 0-10s
+  frames were written to disk but never listed in `report.md` or the stdout
+  stream, so they couldn't be Read. They're now emitted in both.
+
+### Added
+- **Auto-classification (`scripts/classify.py`).** Decides whether a video is
+  worth a full frame pass or is better served transcript-first. The signal is
+  *visual information density*, not motion: `edge_peak / (motion_median + ε)` —
+  high for slides/diagrams/UI/code (frames carry info the transcript doesn't),
+  low for a talking head (the transcript already has the content). A
+  talking-head video drops to a thin confirmation set (~12 frames), saving
+  ~14k image tokens per video; a dense screencast keeps the full budget.
+- **`--mode auto|transcript|balanced|frames`** in `watch.py` (default `auto`).
+  The chosen mode and a one-line rationale are printed to the report so the
+  reader knows whether to lean on the frames or the transcript.
+- 16 new unit tests (`test_classify.py`, `test_subtitle_langs.py`,
+  `test_sampling.py`) covering classification, native-language resolution,
+  even-coverage sampling, and pacing robustness. 23 tests total, all stdlib.
+
 ## [0.2.0] — 2026-05-25
 
 Based on [bradautomates/claude-video](https://github.com/bradautomates/claude-video) v0.1.3 by Bradley Bonanno (MIT). Its pipeline (yt-dlp + ffmpeg + Whisper) is preserved; everything below is additive.

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: watch
-description: Watch a video (URL or local path) like an editor. Extracts scene-change frames, pacing metrics (cuts/min, shot length), and a dense 0-10s hook microscope; pulls transcript from captions or Whisper. Produces an ingest-ready `report.md` and, after answering the user, optionally auto-ingests the analysis into your Obsidian vault (configurable via `$WATCH_VAULT_DIR`) — tied to *why* the user watched it.
+description: Watch a video (URL or local path) like an editor. Auto-classifies the video (talking-head vs visually-dense) and spends frame budget only where it pays off; extracts scene-change frames with even coverage across the whole runtime, pacing metrics (cuts/min, shot length), and a dense 0-10s hook microscope; pulls a native-language transcript from captions (any language) or Whisper. Produces an ingest-ready `report.md` and, after answering the user, optionally auto-ingests the analysis into your Obsidian vault (configurable via `$WATCH_VAULT_DIR`) — tied to *why* the user watched it.
 argument-hint: "<video-url-or-path> [why you're watching it]"
 allowed-tools: Bash, Read, AskUserQuestion
 homepage: https://github.com/taoufik123-collab/claude-watch
@@ -14,7 +14,13 @@ user-invocable: true
 
 You don't have a video input; this skill gives you one. A Python script downloads the video, extracts frames as JPEGs (one per detected shot via scene-change), gets a timestamped transcript (native captions first, then Whisper API as fallback), runs editorial pacing metrics, and microscopes the first 10 seconds at higher density. You then `Read` each frame path to see the images, combine them with the transcript to answer the user, fill the structured `report.md`, and offer to ingest the analysis into Taoufik's Second Brain.
 
-## What v2 does differently
+## What v3 does differently
+
+- **Auto-classification (spend frames only where they pay off)** — before extracting, the skill classifies the video by *visual information density* (`scripts/classify.py`). A talking-head / near-static video gets a thin set of confirmation frames + the transcript (the content lives in the words); a screencast / diagram-heavy / B-roll video gets the full frame budget (the frames carry information the transcript never states). The report tells you which mode you're in so you know whether to lean on the frames or the transcript. Override with `--mode auto|transcript|balanced|frames`.
+- **Native-language transcript (any language)** — the downloader detects the video's native language and pulls that caption track first, instead of the old English-only request that left non-English videos with no transcript at all. The model reads any language and answers in the user's. Override the language order with `$WATCH_SUB_LANGS`.
+- **Even coverage across the whole runtime** — scene-change sampling is two-pass: detect every cut, then sample for even coverage *in time*. A fast-cut intro no longer eats the entire frame budget and starves the body of the video.
+
+## What v2 introduced
 
 - **Scene-change frame sampling** — one frame per detected shot instead of uniform ticks. Cuts the frame budget on long videos while capturing every transition.
 - **Editorial pacing metrics** — cuts/min, mean shot length, motion (when available). Lets you reason about pacing the way an editor does.

--- a/scripts/classify.py
+++ b/scripts/classify.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Decide whether a video is worth analysing frame-by-frame, or transcript-only.
+
+The motivating finding (see CHANGELOG v3): for a *talking-head* video — one
+person, one set, a near-static composition — the 80 extracted frames are
+near-duplicates and add almost nothing over the transcript, while still costing
+~200 image tokens each. For a *visually dense* video — a screencast, a tutorial,
+B-roll with on-screen text/diagrams/code — the frames carry information the
+transcript never states, and are worth every token.
+
+Naively, you'd think "more motion = more worth looking at". The data says the
+opposite: a screencast's diagram sits *still* for seconds while a talking head's
+face and hands move constantly. Motion is not the signal. **Visual information
+density is.** So we measure two cheap things with ffmpeg (no numpy/opencv):
+
+  - motion       : mean luma delta between consecutive 1-fps frames (tblend).
+  - edge_detail  : edge density via `edgedetect` — high when the frame is full
+                   of text / diagrams / UI, low for a person on a soft backdrop.
+
+The discriminator is detail-relative-to-motion:
+
+    info_density = edge_detail_peak / (motion_median + EPS)
+
+High when the frame is rich but stable (slides, code, diagrams) → frames help.
+Low when the frame moves a lot but carries little detail (a talking head)
+→ the transcript already has the content.
+
+The output is a recommendation, not a hard gate — watch.py uses it to pick a
+frame budget and to tell Claude which mode it's in, and the user can override
+with --mode.
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import statistics
+import subprocess
+import sys
+from pathlib import Path
+
+
+# --- Tunables (documented so the thresholds aren't magic numbers) -----------
+
+EPS = 0.05  # floor on motion so the ratio can't blow up on a frozen video.
+
+# info_density = edge_peak / (motion_median + EPS), validated on three videos:
+#   two talking heads scored ~0.55-0.58; a dense screencast scored ~1.69.
+# We place the cut points conservatively wide around that gap.
+DENSE_DENSITY_MIN = 1.10   # at/above => frames carry information -> full budget
+STATIC_DENSITY_MAX = 0.70  # at/below => talking-head -> transcript-first
+
+# A high cut rate alone is enough to warrant frames (fast B-roll montage), even
+# if per-frame detail is modest.
+DENSE_CUTS_PER_MIN = 12.0
+
+# Sample at most this many probe frames — keeps the probe cheap on long videos.
+PROBE_MOTION_FRAMES = 90
+PROBE_EDGE_FRAMES = 40
+
+
+def _run_signalstats(video_path: str, vf: str, max_frames: int) -> list[float]:
+    """Run an ffmpeg filtergraph ending in signalstats+metadata=print, return
+    the per-frame YAVG series normalised to 0..1. Empty on any failure."""
+    if shutil.which("ffmpeg") is None:
+        return []
+    cmd = [
+        "ffmpeg", "-hide_banner", "-loglevel", "info", "-y",
+        "-i", str(Path(video_path).resolve()),
+        "-vf", vf,
+        "-frames:v", str(max_frames),
+        "-an", "-f", "null", "-",
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    vals: list[float] = []
+    for line in (result.stderr or "").splitlines():
+        if "signalstats.YAVG=" in line:
+            try:
+                vals.append(float(line.split("signalstats.YAVG=", 1)[1].split()[0]) / 255.0)
+            except (ValueError, IndexError):
+                pass
+    return vals
+
+
+def _probe_motion(video_path: str) -> list[float]:
+    """Mean luma delta vs previous frame, 1 fps, tiny frames. 0..1 per frame."""
+    vf = ("fps=1.0,scale=64:-2,format=gray,"
+          "tblend=all_mode=difference,signalstats=stat=tout,metadata=print")
+    diffs = _run_signalstats(video_path, vf, PROBE_MOTION_FRAMES)
+    # First tblend output is the frame vs itself (~0); drop a leading zero.
+    if diffs and diffs[0] == 0.0:
+        diffs = diffs[1:]
+    return diffs
+
+
+def _probe_edges(video_path: str) -> list[float]:
+    """Edge density per frame (text/diagram richness), 0.5 fps. 0..1 per frame."""
+    vf = ("fps=0.5,scale=320:-2,format=gray,"
+          "edgedetect=low=0.1:high=0.3,signalstats=stat=tout,metadata=print")
+    return _run_signalstats(video_path, vf, PROBE_EDGE_FRAMES)
+
+
+def classify(
+    video_path: str,
+    pacing: dict | None = None,
+    duration_seconds: float = 0.0,
+) -> dict:
+    """Return a recommendation dict for how to analyse this video.
+
+    {
+      "mode": "transcript" | "balanced" | "frames",
+      "label": human string,
+      "info_density": float,       # edge_peak / (motion_median + EPS)
+      "motion_median": float,
+      "edge_peak": float,
+      "cuts_per_minute": float,
+      "frame_budget": int,         # suggested max frames for the main pass
+      "reason": str,
+      "confident": bool,           # False when signals are ambiguous
+    }
+
+    mode meanings:
+      - "transcript": near-static talking head. Pull the transcript; extract a
+        thin set of frames (confirm setting/speaker/any slides) only.
+      - "frames": visually dense. Extract the full frame budget — the images
+        carry information the transcript doesn't.
+      - "balanced": in between; moderate frame budget.
+    """
+    motion = _probe_motion(video_path)
+    edges = _probe_edges(video_path)
+
+    motion_median = round(statistics.median(motion), 4) if motion else 0.0
+    edge_peak = round(max(edges), 4) if edges else 0.0
+    info_density = round(edge_peak / (motion_median + EPS), 3) if (motion or edges) else 0.0
+
+    cuts_per_min = float((pacing or {}).get("cuts_per_minute", 0.0) or 0.0)
+
+    confident = True
+    if info_density >= DENSE_DENSITY_MIN or cuts_per_min >= DENSE_CUTS_PER_MIN:
+        mode, budget = "frames", 80
+        label = "visually dense (screencast / diagrams / B-roll / on-screen text)"
+        reason = (
+            f"info-density {info_density:.2f} (edge-peak {edge_peak:.3f} over "
+            f"motion-median {motion_median:.3f}), {cuts_per_min:.1f} cuts/min — "
+            "frames carry information the transcript won't. Full frame budget."
+        )
+    elif info_density <= STATIC_DENSITY_MAX and cuts_per_min < DENSE_CUTS_PER_MIN:
+        mode, budget = "transcript", 12
+        label = "talking-head / near-static composition"
+        reason = (
+            f"info-density {info_density:.2f} — the frame moves but carries "
+            "little visual detail (a person, not slides). Transcript holds the "
+            "content; only a thin set of confirmation frames is worth the tokens."
+        )
+    else:
+        mode, budget = "balanced", 40
+        label = "mixed pacing / ambiguous"
+        confident = False
+        reason = (
+            f"info-density {info_density:.2f}, {cuts_per_min:.1f} cuts/min — "
+            "between talking-head and dense. Middle budget; let the hero frames "
+            "settle it."
+        )
+
+    # Short videos: never starve. Cost is trivial; the hook matters more.
+    if 0 < duration_seconds <= 60 and budget < 24:
+        budget = 24
+
+    return {
+        "mode": mode,
+        "label": label,
+        "info_density": info_density,
+        "motion_median": motion_median,
+        "edge_peak": edge_peak,
+        "cuts_per_minute": cuts_per_min,
+        "frame_budget": budget,
+        "reason": reason,
+        "confident": confident,
+    }
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("usage: classify.py <video-path>", file=sys.stderr)
+        raise SystemExit(2)
+    out = classify(sys.argv[1])
+    print(json.dumps(out, indent=2))

--- a/scripts/download.py
+++ b/scripts/download.py
@@ -7,6 +7,7 @@ transcribe.py can parse them without needing Whisper.
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import subprocess
 import sys
@@ -15,6 +16,104 @@ from urllib.parse import urlparse
 
 
 VIDEO_EXTS = {".mp4", ".mkv", ".webm", ".mov", ".m4v", ".avi", ".flv", ".wmv"}
+
+# Fallback chain when we cannot determine the video's native language.
+# Kept deliberately short — the real selection is native-language-first (see
+# resolve_sub_langs). The model understands any language, so we never need to
+# force English; we just need *a* transcript in *some* language.
+DEFAULT_SUB_FALLBACK = ["en", "en-US", "en-orig"]
+
+
+def _probe_metadata(url: str) -> dict:
+    """Single --dump-json probe: title, language, and available sub tracks.
+
+    Returns {} on any failure — callers fall back to the default lang chain.
+    """
+    if shutil.which("yt-dlp") is None:
+        return {}
+    try:
+        result = subprocess.run(
+            ["yt-dlp", "--dump-json", "--skip-download", "--no-playlist", "--", url],
+            capture_output=True, text=True, timeout=90,
+        )
+        if result.returncode != 0 or not result.stdout.strip():
+            return {}
+        return json.loads(result.stdout.splitlines()[0])
+    except (subprocess.TimeoutExpired, json.JSONDecodeError, OSError):
+        return {}
+
+
+def resolve_sub_langs(meta: dict) -> tuple[list[str], str | None]:
+    """Decide which subtitle languages to request, native-language-first.
+
+    Order of precedence:
+      1. $WATCH_SUB_LANGS env override (comma-separated) — user is in control.
+      2. The video's native language (from yt-dlp's `language` field), if it has
+         a subtitle or automatic-caption track. The model reads any language;
+         the native track is the most faithful source (no MT round-trip).
+      3. Any manually-authored subtitle track (creator-provided > auto).
+      4. The DEFAULT_SUB_FALLBACK chain (English variants), then "any auto track".
+
+    Returns (sub_langs, detected_native) where sub_langs is ordered by
+    preference and detected_native is the chosen native code (or None).
+    """
+    env = os.environ.get("WATCH_SUB_LANGS", "").strip()
+    if env:
+        return [s.strip() for s in env.split(",") if s.strip()], None
+
+    # yt-dlp tags placeholder tracks that are never a usable transcript.
+    NON_TRANSCRIPT = {"live_chat"}
+    manual = set((meta.get("subtitles") or {}).keys()) - NON_TRANSCRIPT
+    auto = set((meta.get("automatic_captions") or {}).keys()) - NON_TRANSCRIPT
+    available = manual | auto
+
+    native = meta.get("language")  # e.g. "de", "en", "de-DE" (may be None)
+    # yt-dlp's `language` is often a regional tag (de-DE) while the actually
+    # downloadable caption tracks are the base code + an -orig variant (de,
+    # de-orig). Reduce to the base so we match what's really fetchable.
+    native_base = native.split("-")[0] if native else None
+
+    ordered: list[str] = []
+
+    def _push(code: str | None) -> None:
+        if code and code not in ordered:
+            ordered.append(code)
+
+    # 1. Native language first (the faithful source). Prefer tracks that ACTUALLY
+    #    exist for this video, matching on the base language code so de-DE also
+    #    catches the downloadable `de` / `de-orig` tracks.
+    if native_base:
+        variants = sorted(
+            c for c in available
+            if c == native_base or c.startswith(f"{native_base}-")
+        )
+        # Put the "-orig" (creator's original audio language) track first when
+        # present — it's the most faithful auto-caption source.
+        variants.sort(key=lambda c: (not c.endswith("-orig"), c))
+        for c in variants:
+            _push(c)
+        # Fall back to requesting the base code even if not pre-listed — auto
+        # captions are frequently generatable on demand.
+        _push(native_base)
+        if native and native != native_base:
+            _push(native)  # also try the exact regional tag, last among natives
+
+    # 2. Manually-authored tracks (any language) outrank auto.
+    for c in sorted(manual):
+        _push(c)
+
+    # 3. English fallback chain (only the variants actually available, plus a
+    #    bare "en" as a generatable auto-caption request).
+    for c in DEFAULT_SUB_FALLBACK:
+        if c == "en" or c in available:
+            _push(c)
+
+    if not ordered:
+        ordered = list(DEFAULT_SUB_FALLBACK)
+
+    # Cap the request: native + manual + EN is enough. We never want to ask
+    # yt-dlp for hundreds of machine-translated auto tracks (slow, rate-limits).
+    return ordered[:6], native
 
 
 def is_url(source: str) -> bool:
@@ -41,12 +140,23 @@ def resolve_local(path: str) -> dict:
     }
 
 
-def _pick_subtitle(out_dir: Path) -> Path | None:
+def _pick_subtitle(out_dir: Path, sub_langs: list[str] | None = None) -> Path | None:
+    """Pick the best downloaded .vtt, honouring the resolved language order.
+
+    sub_langs is the preference order from resolve_sub_langs; we return the
+    first track whose language code matches the earliest preference. This keeps
+    the native-language-first intent even when yt-dlp wrote several tracks.
+    """
     candidates = sorted(out_dir.glob("video*.vtt"))
     if not candidates:
         return None
-    preferred = [c for c in candidates if ".en" in c.name]
-    return preferred[0] if preferred else candidates[0]
+    if sub_langs:
+        for lang in sub_langs:
+            for c in candidates:
+                # filenames look like video.de.vtt / video.en-orig.vtt
+                if f".{lang}." in c.name:
+                    return c
+    return candidates[0]
 
 
 def _pick_video(out_dir: Path) -> Path | None:
@@ -66,6 +176,14 @@ def download_url(url: str, out_dir: Path) -> dict:
     out_dir.mkdir(parents=True, exist_ok=True)
     output_template = str(out_dir / "video.%(ext)s")
 
+    # Probe once for native language + available subtitle tracks, then request
+    # the native track first instead of hardcoding English (the v2 behaviour).
+    meta = _probe_metadata(url)
+    sub_langs, native = resolve_sub_langs(meta)
+    if native:
+        print(f"[watch] native language detected: {native}", file=sys.stderr)
+    print(f"[watch] requesting subtitle langs: {','.join(sub_langs)}", file=sys.stderr)
+
     cmd = [
         "yt-dlp",
         "-N", "8",
@@ -74,7 +192,7 @@ def download_url(url: str, out_dir: Path) -> dict:
         "--write-info-json",
         "--write-subs",
         "--write-auto-subs",
-        "--sub-langs", "en,en-US,en-GB,en-orig",
+        "--sub-langs", ",".join(sub_langs),
         "--sub-format", "vtt",
         "--convert-subs", "vtt",
         "--no-playlist",
@@ -93,7 +211,7 @@ def download_url(url: str, out_dir: Path) -> dict:
             f"yt-dlp did not produce a video file in {out_dir} (exit {result.returncode})"
         )
 
-    subtitle = _pick_subtitle(out_dir)
+    subtitle = _pick_subtitle(out_dir, sub_langs)
     info_path = out_dir / "video.info.json"
     info: dict = {}
     if info_path.exists():
@@ -104,17 +222,38 @@ def download_url(url: str, out_dir: Path) -> dict:
                 "uploader": raw.get("uploader") or raw.get("channel"),
                 "duration": raw.get("duration"),
                 "url": raw.get("webpage_url") or url,
+                "language": raw.get("language") or native,
             }
         except Exception as exc:
             print(f"[watch] info.json parse failed: {exc}", file=sys.stderr)
             info = {"url": url}
 
+    if subtitle is not None:
+        # Surface which language we actually got, so the caller/report is honest.
+        print(f"[watch] subtitle track selected: {subtitle.name}", file=sys.stderr)
+    else:
+        print("[watch] no subtitle track downloaded (will try Whisper fallback)",
+              file=sys.stderr)
+
     return {
         "video_path": str(video),
         "subtitle_path": str(subtitle) if subtitle else None,
         "info": info or {"url": url},
+        "subtitle_lang": _lang_from_name(subtitle) if subtitle else None,
+        "native_language": native,
         "downloaded": True,
     }
+
+
+def _lang_from_name(path: Path | None) -> str | None:
+    """Extract the language code from a video.<lang>.vtt filename."""
+    if path is None:
+        return None
+    parts = path.name.split(".")
+    # video.de.vtt -> ["video", "de", "vtt"]; video.en-orig.vtt -> [..., "en-orig", ...]
+    if len(parts) >= 3:
+        return parts[-2]
+    return None
 
 
 def download(source: str, out_dir: Path) -> dict:

--- a/scripts/frames.py
+++ b/scripts/frames.py
@@ -215,55 +215,17 @@ def extract_scene_change(
     for existing in out_dir.glob("frame_*.jpg"):
         existing.unlink()
 
-    # Build a select expression that emits frame 0 + every scene-change frame.
-    select_expr = f"eq(n\\,0)+gt(scene\\,{scene_threshold})"
-    vf = f"select='{select_expr}',metadata=mode=print:file=-,scale={resolution}:-2"
+    # Pass 1 — DETECT all scene-change timestamps across the whole range, with
+    # NO frame cap. The previous one-pass design capped extraction with
+    # `-frames:v max_frames`, which meant a fast-cut intro (e.g. 100 cuts in the
+    # first 20s) consumed the entire budget and the rest of the video was never
+    # sampled at all. We now collect every cut first, then downsample evenly.
+    scene_times = _detect_scene_times(
+        video_path, scene_threshold, start_seconds, end_seconds
+    )
 
-    output_pattern = str(out_dir / "frame_%04d.jpg")
-    cmd: list[str] = [
-        "ffmpeg", "-hide_banner", "-loglevel", "error", "-y",
-    ]
-    if start_seconds is not None:
-        cmd += ["-ss", f"{start_seconds:.3f}"]
-    if end_seconds is not None:
-        cmd += ["-to", f"{end_seconds:.3f}"]
-    cmd += [
-        "-i", str(Path(video_path).resolve()),
-        "-vf", vf,
-        "-vsync", "vfr",
-        "-frames:v", str(max_frames),
-        "-q:v", "4",
-        output_pattern,
-    ]
-
-    result = subprocess.run(cmd, capture_output=True, text=True)
-    if result.returncode != 0:
-        raise SystemExit(f"ffmpeg scene-change extraction failed: {result.stderr.strip()}")
-
-    # Parse pts_time lines from stdout/stderr (ffmpeg version variance).
-    pts_times: list[float] = []
-    for stream in (result.stdout, result.stderr):
-        for line in stream.splitlines():
-            line = line.strip()
-            if "pts_time" in line:
-                for tok in line.split():
-                    if tok.startswith("pts_time:"):
-                        try:
-                            pts_times.append(float(tok.split(":", 1)[1]))
-                        except ValueError:
-                            pass
-                    elif tok.startswith("pts_time="):
-                        try:
-                            pts_times.append(float(tok.split("=", 1)[1]))
-                        except ValueError:
-                            pass
-
-    frames = sorted(out_dir.glob("frame_*.jpg"))
-
-    # Fallback: too few scene frames means this video is static-ish.
-    if len(frames) < uniform_fallback_min:
-        for f in frames:
-            f.unlink()
+    # Fallback: static-ish video (few/no cuts) -> uniform sampling.
+    if len(scene_times) < uniform_fallback_min:
         meta = get_metadata(video_path)
         full_duration = meta["duration_seconds"]
         eff_start = start_seconds if start_seconds is not None else 0.0
@@ -276,19 +238,157 @@ def extract_scene_change(
             start_seconds=start_seconds, end_seconds=end_seconds,
         )
 
-    offset = start_seconds or 0.0
-    if len(pts_times) < len(frames):
-        pts_times += [0.0] * (len(frames) - len(pts_times))
+    # Downsample evenly across the FULL set of cuts so coverage spans the whole
+    # video, not just its busiest stretch. Always keep the first and last cut.
+    selected = _evenly_sample(scene_times, max_frames)
+
+    # Pass 2 — EXTRACT exactly the selected timestamps as JPEGs.
+    frames = _extract_at_times(
+        video_path, out_dir, selected, resolution=resolution
+    )
+
+    # `selected` already holds the absolute timestamps (offset baked in by the
+    # detector), aligned 1:1 with the extracted JPEGs.
+    n = len(frames)
+    ts = selected[:n] if len(selected) >= n else selected + [selected[-1]] * (n - len(selected))
 
     return [
         {
             "index": i,
-            "timestamp_seconds": round(offset + pts_times[i], 2),
+            "timestamp_seconds": round(ts[i], 2),
             "path": str(p),
             "source": "scene-change",
         }
         for i, p in enumerate(frames)
     ]
+
+
+def _detect_scene_times(
+    video_path: str,
+    scene_threshold: float,
+    start_seconds: float | None,
+    end_seconds: float | None,
+) -> list[float]:
+    """Pass 1: return ALL scene-change timestamps (absolute seconds), no cap.
+
+    Uses `select=gt(scene,T)` + `showinfo` over a null muxer (no JPEGs written),
+    so it's cheap. Always includes the range start as the opening shot.
+    """
+    vf = f"select='gt(scene\\,{scene_threshold})',showinfo"
+    cmd: list[str] = ["ffmpeg", "-hide_banner", "-loglevel", "info", "-y"]
+    if start_seconds is not None:
+        cmd += ["-ss", f"{start_seconds:.3f}"]
+    if end_seconds is not None:
+        cmd += ["-to", f"{end_seconds:.3f}"]
+    cmd += ["-i", str(Path(video_path).resolve()), "-vf", vf,
+            "-vsync", "vfr", "-an", "-f", "null", "-"]
+
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    offset = start_seconds or 0.0
+    times: list[float] = [offset]  # opening shot
+    for line in result.stderr.splitlines():
+        if "pts_time:" not in line:
+            continue
+        for tok in line.split():
+            if tok.startswith("pts_time:"):
+                try:
+                    times.append(offset + float(tok.split(":", 1)[1]))
+                except ValueError:
+                    pass
+                break
+    # Strictly increasing, deduplicated.
+    out: list[float] = []
+    for t in sorted(times):
+        if not out or t > out[-1] + 1e-3:
+            out.append(t)
+    return out
+
+
+def _evenly_sample(values: list[float], k: int) -> list[float]:
+    """Pick k scene-change times with good coverage in *time*, not just index.
+
+    A naive even-index pick over the cut list over-weights a fast-cut intro
+    (100 cuts in 20s would still eat most of the budget). Instead we split the
+    timeline into k equal-duration buckets and take the cut nearest each
+    bucket's centre. This guarantees the whole runtime is represented while
+    still snapping every sample onto a real scene boundary.
+    """
+    n = len(values)
+    if n <= k:
+        return list(values)
+    if k <= 1:
+        return [values[0]]
+
+    lo, hi = values[0], values[-1]
+    span = hi - lo
+    if span <= 0:
+        # Degenerate (all cuts at same instant) — fall back to even index pick.
+        return [values[round(i * (n - 1) / (k - 1))] for i in range(k)]
+
+    chosen: list[float] = []
+    used: set[int] = set()
+    for i in range(k):
+        # Centre of bucket i in time.
+        target = lo + span * (i + 0.5) / k
+        # Nearest unused cut to that time.
+        best_j, best_d = None, None
+        for j, v in enumerate(values):
+            if j in used:
+                continue
+            d = abs(v - target)
+            if best_d is None or d < best_d:
+                best_j, best_d = j, d
+        if best_j is not None:
+            used.add(best_j)
+            chosen.append(values[best_j])
+    chosen = sorted(set(chosen))
+    # Guarantee the very first and last cuts are present (open/close shots).
+    # If adding them would exceed k, drop an interior sample to make room so the
+    # endpoints are never the ones trimmed off.
+    if values[0] not in chosen:
+        chosen.insert(0, values[0])
+    if values[-1] not in chosen:
+        chosen.append(values[-1])
+    if len(chosen) > k:
+        first, last = chosen[0], chosen[-1]
+        interior = chosen[1:-1]
+        # Evenly thin the interior down to k-2 items.
+        keep = k - 2
+        if keep <= 0:
+            return [first, last][:k]
+        m = len(interior)
+        interior = [interior[round(i * (m - 1) / (keep - 1))] for i in range(keep)] \
+            if keep > 1 else [interior[m // 2]]
+        chosen = [first] + sorted(set(interior)) + [last]
+    return chosen
+
+
+def _extract_at_times(
+    video_path: str,
+    out_dir: Path,
+    times: list[float],
+    resolution: int = 512,
+) -> list[Path]:
+    """Pass 2: extract one JPEG per timestamp in `times` (absolute seconds).
+
+    Uses fast input seeking per frame. This is robust and order-preserving:
+    frame_0001.jpg corresponds to times[0], and so on.
+    """
+    written: list[Path] = []
+    for i, t in enumerate(times, start=1):
+        out_path = out_dir / f"frame_{i:04d}.jpg"
+        cmd = [
+            "ffmpeg", "-hide_banner", "-loglevel", "error", "-y",
+            "-ss", f"{max(0.0, t):.3f}",
+            "-i", str(Path(video_path).resolve()),
+            "-vf", f"scale={resolution}:-2",
+            "-frames:v", "1", "-q:v", "4",
+            str(out_path),
+        ]
+        res = subprocess.run(cmd, capture_output=True, text=True)
+        if res.returncode == 0 and out_path.exists():
+            written.append(out_path)
+    return written
 
 
 def select_hero_frames(

--- a/scripts/pacing.py
+++ b/scripts/pacing.py
@@ -52,7 +52,18 @@ def compute_pacing(
             "shots": [],
         }
 
-    times = sorted(scene_times)
+    # Deduplicate and keep only strictly-increasing cut times. Repeated or
+    # regressed timestamps (a known artifact of ffmpeg metadata parsing) would
+    # otherwise create zero-length phantom shots and crush the median toward 0.
+    times: list[float] = []
+    for t in sorted(scene_times):
+        if not times or t > times[-1] + 1e-3:
+            times.append(t)
+    if not times:
+        return {
+            "shot_count": 0, "cuts_per_minute": 0.0,
+            "mean_shot_length": 0.0, "median_shot_length": 0.0, "shots": [],
+        }
     if times[0] > 0.01:
         times = [0.0] + times
 
@@ -69,7 +80,13 @@ def compute_pacing(
             shot["motion_score"] = round(float(motion_scores[i]), 3)
         shots.append(shot)
 
-    durations = [s["duration_seconds"] for s in shots]
+    # Statistics over real shots only — exclude sub-frame slivers (<0.1s) that
+    # are parsing noise rather than genuine cuts. Keep them in `shots` for
+    # downstream hero-frame selection, but don't let them skew the profile.
+    durations = [s["duration_seconds"] for s in shots if s["duration_seconds"] >= 0.1]
+    if not durations:
+        durations = [s["duration_seconds"] for s in shots]
+
     return {
         "shot_count": len(shots),
         "cuts_per_minute": round(len(shots) / (video_duration / 60.0), 2),

--- a/scripts/report.py
+++ b/scripts/report.py
@@ -94,9 +94,20 @@ def write_report(
         reason = hook.get("skipped_reason", "n/a")
         lines.append(f"_Skipped: {reason}._")
     else:
-        lines.append(f"- Frames: {len(hook.get('frames', []))} at 2 fps")
+        hook_frames = hook.get("frames", [])
+        lines.append(f"- Frames: {len(hook_frames)} at 2 fps")
+        # Emit the actual frame paths so Claude can Read them. Without this the
+        # hook frames were extracted to disk but never surfaced — the section
+        # was effectively dead. (Bug fix.)
+        if hook_frames:
+            lines.append("")
+            lines.append("  **Read these hook frames with the Read tool:**")
+            for hf in hook_frames:
+                ts = hf.get("timestamp_seconds", 0.0)
+                lines.append(f"  - `{hf['path']}` (t={ts:.1f}s)")
         words = hook.get("words", [])
         if words:
+            lines.append("")
             lines.append(f"- Word-level transcript ({len(words)} words):")
             lines.append("")
             lines.append("```")

--- a/scripts/tests/test_classify.py
+++ b/scripts/tests/test_classify.py
@@ -1,0 +1,55 @@
+"""Unit tests for the auto-classification decision (no ffmpeg needed)."""
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+SCRIPT_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+import classify  # noqa: E402
+
+
+class TestClassify(unittest.TestCase):
+    """We stub the ffmpeg probes so the decision logic is tested in isolation."""
+
+    def _classify_with(self, motion, edges, pacing=None, duration=300.0):
+        with mock.patch.object(classify, "_probe_motion", return_value=motion), \
+             mock.patch.object(classify, "_probe_edges", return_value=edges):
+            return classify.classify("dummy.mp4", pacing=pacing,
+                                     duration_seconds=duration)
+
+    def test_talking_head_is_transcript(self):
+        # Lots of motion (a moving face), little visual detail -> low info-density.
+        r = self._classify_with(motion=[0.15] * 30, edges=[0.06] * 20)
+        self.assertEqual(r["mode"], "transcript")
+        self.assertLessEqual(r["frame_budget"], 12)
+
+    def test_dense_screencast_is_frames(self):
+        # Near-static (low motion) but high edge detail (diagrams) -> dense.
+        r = self._classify_with(motion=[0.02] * 30, edges=[0.16] * 20)
+        self.assertEqual(r["mode"], "frames")
+        self.assertEqual(r["frame_budget"], 80)
+
+    def test_high_cut_rate_forces_frames(self):
+        # Even with modest detail, a fast montage (many cuts/min) -> frames.
+        r = self._classify_with(
+            motion=[0.1] * 30, edges=[0.08] * 20,
+            pacing={"cuts_per_minute": 20.0},
+        )
+        self.assertEqual(r["mode"], "frames")
+
+    def test_short_video_budget_floor(self):
+        # A short talking head still gets a non-trivial floor (hook matters).
+        r = self._classify_with(motion=[0.15] * 30, edges=[0.06] * 20,
+                                duration=45.0)
+        self.assertGreaterEqual(r["frame_budget"], 24)
+
+    def test_no_probe_data_is_safe(self):
+        # ffmpeg returned nothing — must not crash, must not claim "dense".
+        r = self._classify_with(motion=[], edges=[])
+        self.assertIn(r["mode"], {"transcript", "balanced"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_sampling.py
+++ b/scripts/tests/test_sampling.py
@@ -1,0 +1,58 @@
+"""Unit tests for even time-coverage sampling and pacing robustness."""
+import sys
+import unittest
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from frames import _evenly_sample  # noqa: E402
+from pacing import compute_pacing  # noqa: E402
+
+
+class TestEvenlySample(unittest.TestCase):
+
+    def test_fast_intro_does_not_starve_rest(self):
+        # 100 cuts crammed into the first 20s, then sparse cuts to t=800s.
+        # The v2 bug took the first N cuts and never reached the body of the
+        # video. The fix must spread coverage across the whole timeline.
+        intro = [i * 0.2 for i in range(100)]        # 0..19.8s
+        body = [50.0, 120.0, 300.0, 500.0, 700.0, 800.0]
+        cuts = sorted(intro + body)
+
+        picked = _evenly_sample(cuts, 20)
+        self.assertLessEqual(len(picked), 20)
+        # Coverage: at least one sample in the back half of the video.
+        self.assertTrue(any(t > 400 for t in picked),
+                        "sampling never reached the second half of the video")
+        # First and last cuts retained.
+        self.assertEqual(min(picked), cuts[0])
+        self.assertEqual(max(picked), cuts[-1])
+
+    def test_returns_all_when_fewer_than_budget(self):
+        cuts = [0.0, 10.0, 20.0]
+        self.assertEqual(_evenly_sample(cuts, 10), cuts)
+
+    def test_single_budget(self):
+        self.assertEqual(_evenly_sample([5.0, 6.0, 7.0], 1), [5.0])
+
+
+class TestPacingRobustness(unittest.TestCase):
+
+    def test_duplicate_timestamps_do_not_crush_median(self):
+        # The "median 0.04s" bug: many near-identical timestamps create phantom
+        # zero-length shots. The fix dedups and excludes sub-frame slivers.
+        scene_times = [0.0] + [15.0] * 40 + [300.0, 600.0]
+        result = compute_pacing(scene_times, video_duration=810.0)
+        self.assertGreater(result["median_shot_length"], 1.0)
+        self.assertGreater(result["mean_shot_length"], 1.0)
+
+    def test_non_monotonic_input_is_tolerated(self):
+        # Regressed/unsorted timestamps must not raise or produce negatives.
+        result = compute_pacing([0.0, 50.0, 30.0, 80.0], video_duration=100.0)
+        for shot in result["shots"]:
+            self.assertGreaterEqual(shot["duration_seconds"], 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_subtitle_langs.py
+++ b/scripts/tests/test_subtitle_langs.py
@@ -1,0 +1,83 @@
+"""Unit tests for native-language subtitle resolution (the v2 en-only bug)."""
+import os
+import sys
+import unittest
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from download import resolve_sub_langs  # noqa: E402
+
+
+class TestResolveSubLangs(unittest.TestCase):
+
+    def test_german_video_requests_german_first(self):
+        # The exact failure from the v2 review: a German talking-head whose
+        # downloadable auto-caption tracks are `de` and `de-orig`, while the
+        # `language` field is the regional tag `de-DE`.
+        meta = {
+            "language": "de-DE",
+            "subtitles": {},
+            "automatic_captions": {"de": [], "de-orig": [], "en": [], "fr": []},
+        }
+        langs, native = resolve_sub_langs(meta)
+        self.assertEqual(native, "de-DE")
+        # German must come before English.
+        self.assertLess(langs.index("de"), langs.index("en"))
+        # The faithful "-orig" track is preferred first.
+        self.assertEqual(langs[0], "de-orig")
+
+    def test_english_video_still_works(self):
+        meta = {
+            "language": "en-US",
+            "subtitles": {},
+            "automatic_captions": {"en": [], "en-orig": [], "de": []},
+        }
+        langs, native = resolve_sub_langs(meta)
+        self.assertIn("en", langs)
+        self.assertEqual(langs[0].split("-")[0], "en")
+
+    def test_manual_subs_outrank_auto(self):
+        meta = {
+            "language": None,
+            "subtitles": {"es": []},
+            "automatic_captions": {"en": []},
+        }
+        langs, _ = resolve_sub_langs(meta)
+        self.assertIn("es", langs)
+
+    def test_live_chat_is_dropped(self):
+        meta = {
+            "language": "de",
+            "subtitles": {},
+            "automatic_captions": {"de": [], "live_chat": []},
+        }
+        langs, _ = resolve_sub_langs(meta)
+        self.assertNotIn("live_chat", langs)
+
+    def test_env_override_wins(self):
+        os.environ["WATCH_SUB_LANGS"] = "fr, es"
+        try:
+            langs, native = resolve_sub_langs({"language": "de"})
+            self.assertEqual(langs, ["fr", "es"])
+            self.assertIsNone(native)
+        finally:
+            del os.environ["WATCH_SUB_LANGS"]
+
+    def test_request_is_capped(self):
+        # A video with dozens of auto tracks must not produce a huge request.
+        meta = {
+            "language": "ja",
+            "subtitles": {},
+            "automatic_captions": {c: [] for c in
+                                   ["ja", "ja-orig", "en", "de", "fr", "es",
+                                    "it", "pt", "ru", "zh", "ko", "ar"]},
+        }
+        langs, _ = resolve_sub_langs(meta)
+        self.assertLessEqual(len(langs), 6)
+        self.assertEqual(langs[0], "ja-orig")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/watch.py
+++ b/scripts/watch.py
@@ -15,6 +15,7 @@ from pathlib import Path
 SCRIPT_DIR = Path(__file__).parent.resolve()
 sys.path.insert(0, str(SCRIPT_DIR))
 
+from classify import classify  # noqa: E402
 from download import download, is_url  # noqa: E402
 from frames import (  # noqa: E402
     MAX_FPS, auto_fps, auto_fps_focus, extract, extract_scene_change,
@@ -66,6 +67,17 @@ def main() -> int:
         action="store_true",
         help="Skip the dense 0-10s hook re-pass.",
     )
+    ap.add_argument(
+        "--mode",
+        choices=["auto", "transcript", "balanced", "frames"],
+        default="auto",
+        help=(
+            "How to analyse the video. 'auto' (default) classifies talking-head "
+            "vs visually-dense and picks a frame budget accordingly: a talking "
+            "head gets a thin set of frames + the transcript, a screencast/"
+            "B-roll video gets the full frame budget. Force a mode to override."
+        ),
+    )
     args = ap.parse_args()
 
     max_frames = min(args.max_frames, 100)
@@ -101,6 +113,37 @@ def main() -> int:
     effective_end = end_sec if end_sec is not None else full_duration
     effective_duration = max(0.0, effective_end - effective_start)
     focused = start_sec is not None or end_sec is not None
+
+    # --- Auto-classification: spend frame budget only where it pays off -------
+    # Talking-head videos get a thin frame set (content lives in the transcript);
+    # visually-dense videos get the full budget (frames carry information). The
+    # user can force this with --mode; focused ranges always get full density
+    # (they're zooming in deliberately) and skip classification.
+    classification: dict | None = None
+    user_capped = args.max_frames != 80  # explicit --max-frames overrides auto
+    if not focused:
+        if args.mode == "auto":
+            classification = classify(
+                video_path, pacing=None, duration_seconds=full_duration
+            )
+            print(
+                f"[watch] classified as {classification['mode']} "
+                f"({classification['label']}); {classification['reason']}",
+                file=sys.stderr,
+            )
+            if not user_capped:
+                max_frames = min(max_frames, classification["frame_budget"])
+        elif args.mode in ("transcript", "balanced", "frames"):
+            forced_budget = {"transcript": 12, "balanced": 40, "frames": 80}[args.mode]
+            classification = {
+                "mode": args.mode, "label": f"forced via --mode {args.mode}",
+                "frame_budget": forced_budget, "reason": "user override",
+                "confident": True,
+            }
+            if not user_capped:
+                max_frames = min(max_frames, forced_budget)
+            print(f"[watch] mode forced to {args.mode} (budget {max_frames})",
+                  file=sys.stderr)
 
     if focused:
         fps, target = auto_fps_focus(effective_duration, max_frames=max_frames)
@@ -256,6 +299,24 @@ def main() -> int:
     else:
         print("- **Transcript:** none available")
 
+    if classification:
+        print(
+            f"- **Analysis mode:** {classification['mode']} — {classification['label']}"
+        )
+        if classification["mode"] == "transcript":
+            print(
+                "  > This is a talking-head/near-static video: the content lives in "
+                "the **transcript**, and the frames are near-duplicates. Read the few "
+                "frames to confirm setting/speaker, but base your answer on the "
+                "transcript. (Frame budget was trimmed to save tokens.)"
+            )
+        elif classification["mode"] == "frames":
+            print(
+                "  > This is a **visually dense** video: the frames carry information "
+                "the transcript doesn't (on-screen text, diagrams, UI, B-roll). Read "
+                "the frames — they're where the value is."
+            )
+
     if not focused and full_duration > 600:
         mins = int(full_duration // 60)
         print()
@@ -277,6 +338,21 @@ def main() -> int:
     print()
     for frame in frames:
         print(f"- `{frame['path']}` (t={format_time(frame['timestamp_seconds'])})")
+
+    # Surface hook-microscope frames in the main stream too, so they're actually
+    # Read. Previously they were extracted to disk but never printed here.
+    hook_frames = hook_result.get("frames", []) if hook_result else []
+    if hook_frames:
+        print()
+        print("## Hook frames (0-10s, dense)")
+        print()
+        print(
+            "**The first 10 seconds at 2 fps — Read these to analyse the hook.** "
+            "This is the highest-leverage window of the video."
+        )
+        print()
+        for hf in hook_frames:
+            print(f"- `{hf['path']}` (t={hf.get('timestamp_seconds', 0.0):.1f}s)")
 
     print()
     print("## Transcript")


### PR DESCRIPTION
Hey Taoufik 👋 — first off, thank you for `/watch`. The idea of giving Claude an actual *eye* on a video (frames + pacing + hook microscope, not just a transcript) is genuinely clever, and the report.md/ingest design is really nice to build on.

I put the skill head-to-head against a plain "just grab the transcript" approach on three real videos — two German talking-heads and one English screencast — to see exactly where the frames earn their tokens. That little experiment surfaced four things worth fixing, and this PR fixes all of them. **No new dependencies** — still pure ffmpeg + yt-dlp + stdlib, and all tests stay green (7 → 23).

### 🐛 Fixes

**1. Non-English videos got no transcript at all.**
`download.py` hardcoded `--sub-langs en,en-US,en-GB,en-orig`, so both German videos came back with *zero* captions even though YouTube had native auto-captions the whole time. For a talking-head video that's the worst case — the entire content lives in the words. Now it probes the video's native language (`yt-dlp --dump-json`) and requests that track first, reducing the regional tag (`de-DE`) down to the actually-downloadable base/`-orig` tracks (`de`, `de-orig`), with English as fallback. The model reads any language and answers in the user's, so there's no MT in the pipeline. `$WATCH_SUB_LANGS` overrides.

**2. Fast-cut intros starved the rest of the video.**
Scene extraction capped with `-frames:v max_frames` in a single pass. The screencast had ~100 cuts in its first 20 seconds, so the whole 80-frame budget got eaten by the intro and the remaining ~13 minutes were never sampled. Now two-pass: detect *all* cuts, then sample for even coverage **in time** (bucketed), snapping each pick to a real scene boundary.

**3. Pacing median collapsed to ~0.04s.**
`metadata=print` timestamp parsing mis-aligned with the written frames and padded the gaps with `0.0`, creating a pile of phantom zero-length shots. Switched to `showinfo` parsing, and `compute_pacing` now dedups non-increasing timestamps and drops sub-frame slivers from the mean/median.

**4. Hook-microscope frames were extracted but never surfaced.**
The 0-10s frames were written to disk but never listed in `report.md` or the stdout stream, so they couldn't be `Read`. They're now emitted in both places.

### ✨ New: spend frames only where they pay off

The most interesting finding from the experiment: for a talking-head video the 80 frames are near-duplicates and add almost nothing over the transcript — while still costing ~200 image tokens each. For a screencast, the frames carry stuff the transcript never says (on-screen text, diagrams, UI).

So `scripts/classify.py` classifies the video by **visual information density** — counter-intuitively *not* motion (a screencast's diagram sits still while a talking head's face moves constantly), but `edge_peak / (motion_median + ε)`. Talking heads drop to a thin ~12-frame confirmation set (~14k image tokens saved per video); dense videos keep the full budget. New `--mode auto|transcript|balanced|frames` flag, default `auto`, and the report prints which mode it picked + why.

On the three test videos the classifier called all three correctly (the two talking-heads → transcript, the screencast → frames).

### ✅ Tests
16 new stdlib `unittest` cases (`test_classify.py`, `test_subtitle_langs.py`, `test_sampling.py`) covering classification, native-language resolution, even-coverage sampling, and the pacing regressions. 23 total, all passing.

Totally understand if you want to take any of this in a different direction — happy to adjust. Thanks again for building this. 🙏

🤖 Generated with [Claude Code](https://claude.com/claude-code)