### PR TITLE
Fix Whisper on long videos (honor --start/--end) + real motion scores

### DIFF
--- a/scripts/pacing.py
+++ b/scripts/pacing.py
@@ -12,8 +12,12 @@ nullable in the report; can be filled in later if/when opencv is added.
 from __future__ import annotations
 
 import json
+import os
+import shutil
 import statistics
+import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 
@@ -65,7 +69,11 @@ def compute_pacing(
             "duration_seconds": round(duration, 2),
             "motion_score": None,
         }
-        if motion_scores is not None and i < len(motion_scores):
+        if (
+            motion_scores is not None
+            and i < len(motion_scores)
+            and motion_scores[i] is not None
+        ):
             shot["motion_score"] = round(float(motion_scores[i]), 3)
         shots.append(shot)
 
@@ -79,13 +87,108 @@ def compute_pacing(
     }
 
 
-def motion_scores_from_frames(frame_paths: list[str]) -> list[float]:
-    """Cheap stub. Real implementation would run ffmpeg signalstats per shot.
+def _ydif_timeline(video_path: str, sample_fps: float = 4.0) -> list[tuple[float, float]]:
+    """Sample whole-video motion as [(pts_time, YDIF), ...].
 
-    Returning zeros for now — the report works with motion_score=null. Worth
-    revisiting only if a downstream feature actually drives off motion scores.
+    Runs one ffmpeg pass with `signalstats`, whose YDIF metric is the mean
+    absolute luma delta between consecutive frames — a cheap, dependency-free
+    motion proxy. Frames are decimated to `sample_fps` first to keep it fast on
+    long videos. Metadata goes to a temp file (not stdout) so it doesn't collide
+    with the `-f null -` muxer. Returns [] if ffmpeg is missing or the run fails,
+    so callers can fall back to a null motion signal.
     """
-    return [0.0 for _ in frame_paths]
+    if shutil.which("ffmpeg") is None:
+        return []
+
+    handle = tempfile.NamedTemporaryFile(
+        mode="r", suffix=".txt", delete=False, encoding="utf-8"
+    )
+    handle.close()
+    try:
+        vf = f"fps={sample_fps},signalstats,metadata=mode=print:file={handle.name}"
+        cmd = [
+            "ffmpeg", "-hide_banner", "-loglevel", "error", "-y",
+            "-i", str(Path(video_path).resolve()),
+            "-vf", vf, "-an", "-f", "null", "-",
+        ]
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        if result.returncode != 0:
+            return []
+        with open(handle.name, "r", encoding="utf-8", errors="replace") as fh:
+            text = fh.read()
+    finally:
+        try:
+            os.unlink(handle.name)
+        except OSError:
+            pass
+
+    samples: list[tuple[float, float]] = []
+    cur_t: float | None = None
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("frame:"):
+            cur_t = None
+            for tok in line.split():
+                if tok.startswith("pts_time:"):
+                    try:
+                        cur_t = float(tok.split(":", 1)[1])
+                    except ValueError:
+                        cur_t = None
+        elif "signalstats.YDIF" in line and cur_t is not None:
+            try:
+                samples.append((cur_t, float(line.split("=", 1)[1])))
+            except (ValueError, IndexError):
+                pass
+    return samples
+
+
+def _score_shots_from_timeline(
+    shots: list[dict],
+    timeline: list[tuple[float, float]],
+) -> list[float | None]:
+    """Average the YDIF timeline within each shot, normalised so the busiest
+    shot scores 1.0. Pure function — no ffmpeg — so it is unit-testable.
+
+    Returns all-None when the timeline is empty (motion signal unavailable),
+    keeping motion_score nullable downstream.
+    """
+    if not shots:
+        return []
+    if not timeline:
+        return [None] * len(shots)
+
+    raw: list[float] = []
+    for s in shots:
+        start = s["start_seconds"]
+        end = start + s["duration_seconds"]
+        vals = [y for (t, y) in timeline if start <= t < end]
+        if vals:
+            raw.append(statistics.mean(vals))
+        else:
+            # Shot shorter than the sample interval — use the nearest sample.
+            mid = (start + end) / 2.0
+            raw.append(min(timeline, key=lambda ts: abs(ts[0] - mid))[1])
+
+    peak = max(raw) if raw else 0.0
+    if peak <= 0:
+        return [0.0] * len(shots)
+    return [round(r / peak, 3) for r in raw]
+
+
+def motion_scores_for_shots(
+    video_path: str,
+    shots: list[dict],
+    sample_fps: float = 4.0,
+) -> list[float | None]:
+    """Per-shot motion score in [0,1], normalised so the busiest shot = 1.0.
+
+    Drives hero-frame selection (frames.select_hero_frames picks the
+    highest-motion shot). Returns a list aligned with `shots`, or all-None if
+    the motion signal can't be computed.
+    """
+    if not shots:
+        return []
+    return _score_shots_from_timeline(shots, _ydif_timeline(video_path, sample_fps))
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_pacing.py
+++ b/scripts/tests/test_pacing.py
@@ -6,7 +6,7 @@ from pathlib import Path
 SCRIPT_DIR = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(SCRIPT_DIR))
 
-from pacing import compute_pacing  # noqa: E402
+from pacing import compute_pacing, _score_shots_from_timeline  # noqa: E402
 
 
 class TestPacing(unittest.TestCase):
@@ -52,6 +52,44 @@ class TestPacing(unittest.TestCase):
         )
         scores = [s["motion_score"] for s in result["shots"]]
         self.assertEqual(scores, [0.1, 0.5, 0.9])
+
+    def test_motion_scores_tolerates_none_entries(self):
+        # A null motion signal must not crash attachment.
+        result = compute_pacing(
+            scene_times=[0.0, 10.0, 20.0],
+            video_duration=30.0,
+            motion_scores=[None, None, None],
+        )
+        scores = [s["motion_score"] for s in result["shots"]]
+        self.assertEqual(scores, [None, None, None])
+
+
+class TestMotionScoring(unittest.TestCase):
+
+    def _shots(self, *spans):
+        return [{"start_seconds": s, "duration_seconds": d} for s, d in spans]
+
+    def test_normalises_to_busiest_shot(self):
+        shots = self._shots((0.0, 2.0), (2.0, 2.0))
+        timeline = [(0.5, 10.0), (1.5, 10.0), (2.5, 40.0), (3.5, 40.0)]
+        scores = _score_shots_from_timeline(shots, timeline)
+        self.assertEqual(scores, [0.25, 1.0])
+
+    def test_empty_timeline_is_all_none(self):
+        shots = self._shots((0.0, 2.0), (2.0, 2.0))
+        self.assertEqual(_score_shots_from_timeline(shots, []), [None, None])
+
+    def test_short_shot_uses_nearest_sample(self):
+        # Shot shorter than the sample interval has no sample inside it.
+        shots = self._shots((1.0, 0.05))
+        timeline = [(0.0, 5.0), (1.5, 20.0)]
+        # nearest sample to the shot midpoint (1.025s) is t=1.5 → peak → 1.0
+        self.assertEqual(_score_shots_from_timeline(shots, timeline), [1.0])
+
+    def test_all_zero_motion_stays_zero(self):
+        shots = self._shots((0.0, 2.0), (2.0, 2.0))
+        timeline = [(0.5, 0.0), (2.5, 0.0)]
+        self.assertEqual(_score_shots_from_timeline(shots, timeline), [0.0, 0.0])
 
 
 if __name__ == "__main__":

--- a/scripts/watch.py
+++ b/scripts/watch.py
@@ -21,7 +21,7 @@ from frames import (  # noqa: E402
     format_time, get_metadata, parse_time, select_hero_frames,
 )
 from hook import analyse_hook  # noqa: E402
-from pacing import compute_pacing  # noqa: E402
+from pacing import compute_pacing, motion_scores_for_shots  # noqa: E402
 from report import write_report  # noqa: E402
 from transcribe import filter_range, format_transcript, parse_vtt  # noqa: E402
 from whisper import load_api_key, transcribe_video  # noqa: E402
@@ -155,6 +155,16 @@ def main() -> int:
         video_duration=effective_duration,
         motion_scores=None,
     )
+    # Per-shot motion (ffmpeg signalstats) — only meaningful with real shot
+    # boundaries from scene-change detection. Feeds hero-frame selection.
+    if sampling_mode == "scene-change" and pacing["shots"]:
+        print("[watch] scoring per-shot motion (ffmpeg signalstats)…", file=sys.stderr)
+        motion = motion_scores_for_shots(video_path, pacing["shots"])
+        pacing = compute_pacing(
+            scene_times=scene_times,
+            video_duration=effective_duration,
+            motion_scores=motion,
+        )
 
     # Hook microscope: dense pass over [0, 10s] when not in focused mode.
     if (not args.no_hook_microscope) and (not focused) and full_duration >= 30.0:

--- a/scripts/watch.py
+++ b/scripts/watch.py
@@ -184,6 +184,9 @@ def main() -> int:
     transcript_segments: list[dict] = []
     transcript_text: str | None = None
     transcript_source: str | None = None
+    # Captures *why* a transcript is missing, so the report states the real
+    # cause (e.g. audio too large) instead of a generic "no API key" message.
+    transcript_failure: str | None = None
     if dl.get("subtitle_path"):
         try:
             all_segments = parse_vtt(dl["subtitle_path"])
@@ -202,11 +205,21 @@ def main() -> int:
                     work / "audio.mp3",
                     backend=backend,
                     api_key=api_key,
+                    start_seconds=start_sec,
+                    end_seconds=end_sec,
                 )
+                # Whisper timestamps are relative to the trimmed clip (starts at
+                # 0); shift them onto the absolute timeline so they align with
+                # the absolute frame timestamps.
+                if start_sec:
+                    for seg in all_segments:
+                        seg["start"] += start_sec
+                        seg["end"] += start_sec
                 transcript_segments = filter_range(all_segments, start_sec, end_sec) if focused else all_segments
                 transcript_text = format_transcript(transcript_segments)
                 transcript_source = f"whisper ({used_backend})"
             except SystemExit as exc:
+                transcript_failure = f"Whisper transcription failed: {exc}"
                 print(f"[watch] whisper fallback failed: {exc}", file=sys.stderr)
         else:
             hint = (
@@ -214,11 +227,14 @@ def main() -> int:
                 if args.whisper else
                 "no subtitles and no Whisper API key found"
             )
+            transcript_failure = hint
             setup_py = SCRIPT_DIR / "setup.py"
             print(
                 f"[watch] {hint} — run `python3 {setup_py}` to enable the Whisper fallback",
                 file=sys.stderr,
             )
+    elif not transcript_segments and args.no_whisper:
+        transcript_failure = "no subtitles and Whisper disabled with --no-whisper"
 
     info = dl.get("info") or {}
 
@@ -305,12 +321,14 @@ def main() -> int:
         print(f"_No transcript lines fell inside {format_time(effective_start)} → {format_time(effective_end)}._")
     else:
         setup_py = SCRIPT_DIR / "setup.py"
-        print(
-            "_No transcript available — proceed with frames only. "
-            "Captions were missing and the Whisper fallback was unavailable "
-            "(no API key set, or `--no-whisper` was used). "
-            f"Run `python3 {setup_py}` to enable Whisper, then re-run._"
-        )
+        reason = transcript_failure or "captions were missing and no Whisper API key was found"
+        msg = f"_No transcript available — proceed with frames only. Reason: {reason}."
+        # Only point at setup.py when a key is actually missing — not for size
+        # limits, disabled Whisper, or API errors where the key is fine.
+        if "key" in reason.lower() and "missing" in reason.lower() or "no Whisper API key" in reason:
+            msg += f" Run `python3 {setup_py}` to enable Whisper, then re-run."
+        msg += "_"
+        print(msg)
 
     print()
     print("---")

--- a/scripts/whisper.py
+++ b/scripts/whisper.py
@@ -31,6 +31,11 @@ GROQ_MODEL = "whisper-large-v3"
 OPENAI_ENDPOINT = "https://api.openai.com/v1/audio/transcriptions"
 OPENAI_MODEL = "whisper-1"
 
+# Both Groq and OpenAI reject audio uploads larger than 25 MB. At ~480 kB/min
+# (mono 16 kHz 64 kbps), that caps a single transcription at roughly 50 minutes
+# of audio — longer videos must be watched in sections via --start/--end.
+WHISPER_MAX_MB = 25.0
+
 
 def load_api_key(preferred: str | None = None) -> tuple[str, str] | tuple[None, None]:
     """Return (backend, api_key). Prefers Groq, falls back to OpenAI.
@@ -82,17 +87,33 @@ def load_api_key(preferred: str | None = None) -> tuple[str, str] | tuple[None, 
     return None, None
 
 
-def extract_audio(video_path: str, out_path: Path) -> Path:
-    """Extract mono 16kHz 64kbps mp3 — ~480 kB/min, fits any Whisper limit."""
+def extract_audio(
+    video_path: str,
+    out_path: Path,
+    start_seconds: float | None = None,
+    end_seconds: float | None = None,
+) -> Path:
+    """Extract mono 16kHz 64kbps mp3 — ~480 kB/min.
+
+    When start/end are given, only that range is extracted — essential for
+    long videos, where the full audio would exceed the Whisper upload limit
+    (see WHISPER_MAX_MB). Trim flags go before -i so ffmpeg seeks without
+    decoding the whole file.
+    """
     if shutil.which("ffmpeg") is None:
         raise SystemExit("ffmpeg is not installed. Install with: brew install ffmpeg")
 
     out_path.parent.mkdir(parents=True, exist_ok=True)
-    cmd = [
-        "ffmpeg",
-        "-hide_banner",
-        "-loglevel", "error",
-        "-y",
+    cmd = ["ffmpeg", "-hide_banner", "-loglevel", "error", "-y"]
+    if start_seconds is not None:
+        cmd += ["-ss", f"{start_seconds:.3f}"]
+    if end_seconds is not None:
+        # Use -t (duration) rather than -to: with -ss before -i the output PTS
+        # resets to 0, so an absolute -to would be misinterpreted across ffmpeg
+        # versions. Duration is unambiguous.
+        start = start_seconds or 0.0
+        cmd += ["-t", f"{max(0.0, end_seconds - start):.3f}"]
+    cmd += [
         "-i", str(Path(video_path).resolve()),
         "-vn",
         "-acodec", "libmp3lame",
@@ -277,10 +298,14 @@ def transcribe_video(
     audio_out: Path,
     backend: str | None = None,
     api_key: str | None = None,
+    start_seconds: float | None = None,
+    end_seconds: float | None = None,
 ) -> tuple[list[dict], str]:
     """Run the full flow: extract audio → upload → parse segments.
 
-    Returns (segments, backend_used). Raises SystemExit on any failure.
+    When start/end are given, only that range is transcribed — keeps long
+    videos under the Whisper upload limit. Returns (segments, backend_used).
+    Raises SystemExit on any failure.
     """
     if backend is None or api_key is None:
         detected_backend, detected_key = load_api_key()
@@ -296,8 +321,17 @@ def transcribe_video(
         )
 
     print(f"[watch] extracting audio for Whisper ({backend})…", file=sys.stderr)
-    audio_path = extract_audio(video_path, audio_out)
+    audio_path = extract_audio(video_path, audio_out, start_seconds, end_seconds)
     size_kb = audio_path.stat().st_size / 1024
+    size_mb = size_kb / 1024
+    if size_mb > WHISPER_MAX_MB:
+        approx_min = int(size_mb / 0.48)  # ~480 kB per minute of audio
+        raise SystemExit(
+            f"audio is {size_mb:.1f} MB — over the {WHISPER_MAX_MB:.0f} MB "
+            f"{backend} Whisper upload limit (~{approx_min} min of audio). "
+            "Re-run on a shorter section with --start/--end "
+            "(e.g. --start 0 --end 30:00) to transcribe it in chunks."
+        )
     print(f"[watch] audio: {size_kb:.0f} kB — uploading to {backend} Whisper…", file=sys.stderr)
 
     if backend == "groq":


### PR DESCRIPTION
Two independent improvements, each in its own commit.

## 1. fix(whisper): honor --start/--end when extracting audio + accurate failure reasons

`extract_audio()` ignored the focus range and always sent the **full** video's
audio to Whisper. On long videos that audio exceeds the 25 MB upload limit and
the request fails with HTTP 413 — and crucially, watching in sections via
`--start/--end` could never help, because the trim was never applied to the audio.

This commit:
- Trims the extracted audio to `[start, end]` via ffmpeg `-ss`/`-t`.
- Shifts the (clip-relative) Whisper timestamps back onto the absolute timeline so
  they align with the absolute frame timestamps.
- Adds a pre-flight `WHISPER_MAX_MB` (25 MB) guard that fails with an actionable
  message ("re-run on a shorter section") instead of a cryptic 413.
- Replaces the misleading "No transcript available — no API key set" report line
  with the real cause (the key can be valid; the audio was simply too large).

Verified end-to-end: a 90-min video that previously returned 42 MB → 413 → no
transcript now transcribes correctly in 30-min sections (~14 MB each).

## 2. feat(pacing): real per-shot motion scores via ffmpeg signalstats

`motion_scores_from_frames()` was a stub returning zeros, which left
`select_hero_frames()`' highest-motion branch (frames.py) effectively dead.
Replaced with a real implementation:
- One ffmpeg `signalstats` pass (YDIF = mean luma delta vs previous frame) as a
  cheap motion proxy, decimated to a sample fps.
- Per-shot averaging normalised so the busiest shot scores 1.0, with a
  nearest-sample fallback for ultra-short shots.
- Pure normalisation logic split out for unit testing; new tests added.
- Graceful fallback to a null motion signal when ffmpeg/signalstats is unavailable.

All existing tests pass; pacing test count went 4 → 9.

Attribution preserved (AUTHORS.md / LICENSE untouched).