### PR TITLE
Add local Whisper backend (faster-whisper, no API key)

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -14,3 +14,10 @@ the MIT license, © 2026 Bradley Bonanno.
 
 Scene-change frame extraction, the 0-10s hook microscope, the structured `report.md`, and
 optional Obsidian auto-save, on top of Bradley's pipeline.
+
+## Contributors
+
+**MrBill700** — [MrBill700](https://github.com/MrBill700)
+
+Local Whisper backend (`scripts/whisper_local.py`) — on-machine faster-whisper transcription
+with no API key, as a drop-in alternative to the Groq/OpenAI backends.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to `/watch` are documented here.
 
+## [0.3.0] — 2026-06-30
+
+### Added
+- Local Whisper backend — run transcription on-machine via [faster-whisper](https://github.com/SYSTRAN/faster-whisper) instead of the Groq/OpenAI APIs. No API key, and the audio never leaves the machine.
+  - New `scripts/whisper_local.py` bridge — transcribes a single audio file and prints the same `{start, end, text}` (and optional word-level) JSON the API backends produce, so frame/transcript alignment and the 0-10s hook microscope work identically. Defaults to `large-v3` / `float16` / beam 1 / VAD on, CUDA with CPU/int8 fallback.
+  - `scripts/whisper.py` gains a `local` backend: `local_enabled()` + `_local_python()` resolution (explicit `$WATCH_WHISPER_LOCAL_PYTHON`, else the current interpreter if it can import `faster_whisper`), a `"local"` short-circuit in `load_api_key()`, and `local` branches in `transcribe_video()` / `transcribe_audio()`.
+  - Opt in with `WATCH_WHISPER_LOCAL=1`; when set and resolvable it becomes the default backend (captions still tried first). Force per-run with `--whisper local`.
+  - `scripts/setup.py` `--check` / `--json` report `ready` with `whisper_backend: local` when local mode is configured, so no API key is requested.
+- New `--whisper local` choice in `scripts/watch.py`.
+
+### Changed
+- README documents the local backend, the `WATCH_WHISPER_LOCAL` / `WATCH_WHISPER_LOCAL_PYTHON` env vars, and a new "no key" row in the capabilities table. `SKILL.md` Transcription section describes the local path.
+
 ## [0.2.0] — 2026-05-25
 
 Based on [bradautomates/claude-video](https://github.com/bradautomates/claude-video) v0.1.3 by Bradley Bonanno (MIT). Its pipeline (yt-dlp + ffmpeg + Whisper) is preserved; everything below is additive.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Codex / generic skills:
 git clone https://github.com/taoufik123-collab/claude-watch.git ~/.codex/skills/watch
 ```
 
-Zero config to start — `yt-dlp` and `ffmpeg` install on first run via `brew` on macOS (Linux/Windows print exact commands). Captions cover most public videos for free. Whisper API key is only needed when a video has no captions. Set `$WATCH_VAULT_DIR` to point at your Obsidian vault for auto-save, or leave it unset and the skill skips the ingest step quietly.
+Zero config to start — `yt-dlp` and `ffmpeg` install on first run via `brew` on macOS (Linux/Windows print exact commands). Captions cover most public videos for free. A Whisper backend is only needed when a video has no captions — use a [local faster-whisper](#local-whisper-no-api-key) install (no key) or a Groq/OpenAI key. Set `$WATCH_VAULT_DIR` to point at your Obsidian vault for auto-save, or leave it unset and the skill skips the ingest step quietly.
 
 ## What's inside
 
@@ -135,9 +135,25 @@ Captions cover the majority of public videos for free. The Whisper fallback only
 | Capability | What you need | Cost |
 |------------|---------------|------|
 | Download + native captions | `yt-dlp` + `ffmpeg` | Free |
+| Whisper fallback (local, no key) | [faster-whisper](https://github.com/SYSTRAN/faster-whisper) + `WATCH_WHISPER_LOCAL=1` | Free, on-machine, private |
 | Whisper fallback (preferred) | [Groq API key](https://console.groq.com/keys) — `whisper-large-v3` | Cheap, fast |
 | Whisper fallback (alt) | [OpenAI API key](https://platform.openai.com/api-keys) — `whisper-1` | Standard pricing |
 | Disable Whisper entirely | `--no-whisper` | Free, frames-only when no captions |
+
+### Local Whisper (no API key)
+
+Prefer to keep audio on your machine, or just don't want to manage an API key? Point the Whisper fallback at a local [faster-whisper](https://github.com/SYSTRAN/faster-whisper) install instead of Groq/OpenAI.
+
+```bash
+export WATCH_WHISPER_LOCAL=1
+# Optional: an interpreter whose env has faster-whisper (e.g. a GPU venv).
+# Omit it and the skill uses its own interpreter if faster-whisper is importable there.
+export WATCH_WHISPER_LOCAL_PYTHON="/path/to/python-with-faster-whisper"
+```
+
+When `WATCH_WHISPER_LOCAL` is set and a faster-whisper interpreter is resolvable, it becomes the default backend: captions are still tried first, and when a video has none the audio is transcribed locally via `scripts/whisper_local.py` — same `{start, end, text}` (and word-level) output the API backends produce, so frame/transcript alignment and the hook microscope work identically. `setup.py --check` treats this as "ready" (no key needed). Force it explicitly with `--whisper local`, or override per-run with `--whisper groq|openai`.
+
+Defaults mirror a typical accuracy-first config (`large-v3` / `float16` / beam 1 / VAD on), using CUDA when available and falling back to CPU/int8. Note the model loads per invocation, so local transcription adds a few seconds of startup over an API call.
 
 ## Usage
 
@@ -160,7 +176,7 @@ Other knobs (passed to `scripts/watch.py`):
 - `--max-frames N` — lower the frame cap for a tighter token budget.
 - `--resolution W` — bump frame width to 1024 px when Claude needs to read on-screen text (slides, terminals, code).
 - `--fps F` — override the auto-fps calculation (still capped at 2 fps).
-- `--whisper groq|openai` — force a specific Whisper backend.
+- `--whisper groq|openai|local` — force a specific Whisper backend (`local` = on-machine faster-whisper, see [Local Whisper](#local-whisper-no-api-key)).
 - `--no-whisper` — disable transcription entirely; frames only.
 - `--out-dir DIR` — keep working files somewhere specific (default: auto-generated tmp dir).
 
@@ -181,7 +197,8 @@ Other knobs (passed to `scripts/watch.py`):
 │   ├── download.py          # yt-dlp wrapper
 │   ├── frames.py            # ffmpeg frame extraction + auto-fps logic
 │   ├── transcribe.py        # VTT parsing + dedupe + Whisper orchestration
-│   ├── whisper.py           # Groq / OpenAI clients (pure stdlib)
+│   ├── whisper.py           # Groq / OpenAI clients (pure stdlib) + local backend dispatch
+│   ├── whisper_local.py     # local faster-whisper bridge (no API key)
 │   ├── setup.py             # preflight + installer
 │   └── build-skill.sh       # build dist/watch.skill for claude.ai upload
 ├── hooks/                   # SessionStart status hook (Claude Code only)

--- a/SKILL.md
+++ b/SKILL.md
@@ -116,7 +116,7 @@ Optional flags:
 - `--resolution W` — change frame width in px (default 512; bump to 1024 only if the user needs to read on-screen text)
 - `--fps F` — override auto-fps (clamped to 2 fps max). Setting `--fps` disables scene-change sampling.
 - `--out-dir DIR` — keep working files somewhere specific (default: an auto-generated tmp dir)
-- `--whisper groq|openai` — force a specific Whisper backend (default: prefer Groq if both keys exist)
+- `--whisper groq|openai|local` — force a specific Whisper backend. `local` runs faster-whisper on-machine (no key); default prefers `local` when `WATCH_WHISPER_LOCAL` is set, else Groq, then OpenAI
 - `--no-whisper` — disable the Whisper fallback entirely (frames-only if no captions)
 - `--no-scene-change` — force uniform frame sampling (debug only; usually leave on)
 - `--no-hook-microscope` — skip the 0-10s dense pass (saves ~1 Whisper call)
@@ -221,14 +221,15 @@ The "different angle" path is what makes /watch truly plug-and-play — the user
 
 ## Transcription
 
-The script gets a timestamped transcript in one of two ways:
+The script gets a timestamped transcript in one of these ways:
 
 1. **Native captions (free, preferred).** yt-dlp pulls manual or auto-generated subtitles from the source platform if available.
-2. **Whisper API fallback.** If no captions came back (or the source is a local file), the script extracts audio (`ffmpeg -vn -ac 1 -ar 16000 -b:a 64k`, ~0.5 MB/min) and uploads it to whichever Whisper API has a key configured:
+2. **Local Whisper (no API key).** When `WATCH_WHISPER_LOCAL` is set and a faster-whisper interpreter is resolvable, captionless audio is transcribed on-machine via `scripts/whisper_local.py` — run by `$WATCH_WHISPER_LOCAL_PYTHON` (e.g. a dedicated GPU venv), or the skill's own interpreter if it can import `faster_whisper`. This is the default fallback when enabled; force it with `--whisper local`. Output matches the API backends ({start, end, text} + optional word-level), so nothing downstream changes.
+3. **Whisper API fallback.** If no captions came back (or the source is a local file) and local mode is off, the script extracts audio (`ffmpeg -vn -ac 1 -ar 16000 -b:a 64k`, ~0.5 MB/min) and uploads it to whichever Whisper API has a key configured:
    - **Groq** — `whisper-large-v3`. Preferred default: cheaper, faster. Get a key at console.groq.com/keys.
    - **OpenAI** — `whisper-1`. Fallback. Get a key at platform.openai.com/api-keys.
 
-Both keys live in `~/.config/watch/.env`. The script prefers Groq when both are set; override with `--whisper openai` to force OpenAI. Use `--no-whisper` to skip the fallback entirely.
+API keys live in `~/.config/watch/.env`. The script prefers Groq when both are set; override with `--whisper openai` to force OpenAI. Local mode needs no key. Use `--no-whisper` to skip the fallback entirely.
 
 ## Failure modes and handling
 

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -95,7 +95,21 @@ def _read_env_key(name: str) -> str | None:
     return None
 
 
+def _local_whisper_ready() -> bool:
+    """True when local faster-whisper is configured (no API key needed)."""
+    flag = (os.environ.get("WATCH_WHISPER_LOCAL") or "").strip().lower()
+    if flag not in ("1", "true", "yes", "on"):
+        return False
+    explicit = os.environ.get("WATCH_WHISPER_LOCAL_PYTHON")
+    if explicit:
+        return Path(explicit).exists()
+    import importlib.util
+    return importlib.util.find_spec("faster_whisper") is not None
+
+
 def _have_api_key() -> tuple[bool, str | None]:
+    if _local_whisper_ready():
+        return True, "local"
     if _read_env_key("GROQ_API_KEY"):
         return True, "groq"
     if _read_env_key("OPENAI_API_KEY"):

--- a/scripts/watch.py
+++ b/scripts/watch.py
@@ -46,9 +46,10 @@ def main() -> int:
     )
     ap.add_argument(
         "--whisper",
-        choices=["groq", "openai"],
+        choices=["groq", "openai", "local"],
         default=None,
-        help="Force a specific Whisper backend. Default: prefer Groq, fall back to OpenAI.",
+        help="Force a Whisper backend. Default: 'local' if WATCH_WHISPER_LOCAL is set, "
+             "else prefer Groq, fall back to OpenAI.",
     )
     ap.add_argument(
         "--intent",

--- a/scripts/whisper.py
+++ b/scripts/whisper.py
@@ -31,12 +31,78 @@ GROQ_MODEL = "whisper-large-v3"
 OPENAI_ENDPOINT = "https://api.openai.com/v1/audio/transcriptions"
 OPENAI_MODEL = "whisper-1"
 
+# --- Local backend (faster-whisper, on-machine) ------------------------------
+# Runs Whisper locally instead of calling an API: no key required, and the audio
+# never leaves the machine. Opt in with WATCH_WHISPER_LOCAL=1. The actual
+# transcription runs in whisper_local.py, executed by an interpreter that has
+# faster-whisper installed (resolved by _local_python below).
+LOCAL_ENABLE_ENV = "WATCH_WHISPER_LOCAL"
+LOCAL_PYTHON_ENV = "WATCH_WHISPER_LOCAL_PYTHON"
+
+
+def _local_python() -> str | None:
+    """Interpreter that can run faster-whisper, or None if unavailable.
+
+    Resolution order:
+      1. $WATCH_WHISPER_LOCAL_PYTHON — explicit path to a python whose
+         environment has faster-whisper installed (e.g. a dedicated GPU venv,
+         such as F:\\Programs\\TranscribeWhisper\\venv\\Scripts\\python.exe).
+      2. The current interpreter, if it can already import faster_whisper.
+    """
+    explicit = os.environ.get(LOCAL_PYTHON_ENV)
+    if explicit:
+        return explicit if Path(explicit).exists() else None
+    try:
+        import importlib.util
+        if importlib.util.find_spec("faster_whisper") is not None:
+            return sys.executable
+    except Exception:
+        return None
+    return None
+
+
+def local_enabled() -> bool:
+    """True when local faster-whisper should be the default Whisper backend."""
+    flag = os.environ.get(LOCAL_ENABLE_ENV, "").strip().lower()
+    return flag in ("1", "true", "yes", "on") and _local_python() is not None
+
+
+def _transcribe_local(audio_path: Path, word_timestamps: bool = False) -> tuple[list[dict], list[dict]]:
+    """Run faster-whisper locally via the bridge. Returns (segments, words)."""
+    py = _local_python()
+    if not py:
+        raise SystemExit(
+            "local whisper requested but the faster-whisper interpreter was not found. "
+            f"Set {LOCAL_PYTHON_ENV} to a python.exe that has faster-whisper installed."
+        )
+    bridge = Path(__file__).resolve().parent / "whisper_local.py"
+    cmd = [py, str(bridge), str(audio_path.resolve())]
+    if word_timestamps:
+        cmd.append("--words")
+    print("[watch] transcribing locally via faster-whisper (no API)…", file=sys.stderr)
+    # stderr inherits the parent's so model-load/progress lines stream live;
+    # only stdout (the JSON payload) is captured.
+    result = subprocess.run(cmd, stdout=subprocess.PIPE, text=True)
+    if result.returncode != 0:
+        raise SystemExit(f"local whisper failed (exit {result.returncode}) — see the [whisper-local] lines above")
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"local whisper returned non-JSON: {exc}: {result.stdout[:200]}")
+    return data.get("segments") or [], data.get("words") or []
+
 
 def load_api_key(preferred: str | None = None) -> tuple[str, str] | tuple[None, None]:
     """Return (backend, api_key). Prefers Groq, falls back to OpenAI.
 
     If `preferred` is "groq" or "openai", only that backend's key is considered.
+    The pseudo-backend "local" needs no key — it returns ("local", "local") so
+    downstream truthiness guards pass while routing to faster-whisper.
     """
+    if preferred == "local":
+        return "local", "local"
+    if preferred is None and local_enabled():
+        return "local", "local"
     def _from_env(name: str) -> str | None:
         value = os.environ.get(name)
         return value.strip() if value else None
@@ -298,6 +364,14 @@ def transcribe_video(
     print(f"[watch] extracting audio for Whisper ({backend})…", file=sys.stderr)
     audio_path = extract_audio(video_path, audio_out)
     size_kb = audio_path.stat().st_size / 1024
+
+    if backend == "local":
+        segments, _ = _transcribe_local(audio_path, word_timestamps=False)
+        if not segments:
+            raise SystemExit("local whisper returned no transcript segments")
+        print(f"[watch] transcribed {len(segments)} segments via local faster-whisper", file=sys.stderr)
+        return segments, "local"
+
     print(f"[watch] audio: {size_kb:.0f} kB — uploading to {backend} Whisper…", file=sys.stderr)
 
     if backend == "groq":
@@ -332,6 +406,10 @@ def transcribe_audio(
         api_key = api_key or detected_key
     if not backend or not api_key:
         raise SystemExit("No Whisper API key available for transcribe_audio()")
+
+    if backend == "local":
+        segments, words = _transcribe_local(audio_path, word_timestamps=word_timestamps)
+        return segments, "local", words
 
     if backend == "groq":
         endpoint, model = GROQ_ENDPOINT, GROQ_MODEL

--- a/scripts/whisper_local.py
+++ b/scripts/whisper_local.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Local Whisper bridge for /watch — runs faster-whisper instead of an API.
+
+This script is invoked as a subprocess by an interpreter that has
+faster-whisper (+ torch / CUDA) installed — which may differ from the skill's
+own Python. whisper.py resolves that interpreter via $WATCH_WHISPER_LOCAL_PYTHON
+(or the current interpreter if it can import faster_whisper):
+
+    <python-with-faster-whisper> whisper_local.py <audio> [--words]
+
+It transcribes a single audio file and prints JSON to stdout in the exact
+shape whisper.py expects, so the local path is a drop-in for the Groq/OpenAI
+backend:
+
+    {"segments": [{"start": float, "end": float, "text": str}, ...],
+     "words":    [{"word": str, "start": float, "end": float}, ...],   # [] unless --words
+     "language": "en", "model": "large-v3", "device": "cuda",
+     "backend": "local-faster-whisper"}
+
+All diagnostics go to stderr; stdout is pure JSON so the caller can json.loads it.
+Defaults (large-v3 / float16 / beam 1 / VAD on / greedy) favour accuracy; CUDA
+is used when available, falling back to CPU/int8. Override with the flags below.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+
+# Defaults mirror TranscribeWhisper's transcribe.py config block.
+DEFAULT_MODEL = "large-v3"
+DEFAULT_COMPUTE = "float16"
+DEFAULT_BEAM = 1
+
+
+def _log(msg: str) -> None:
+    print(f"[whisper-local] {msg}", file=sys.stderr, flush=True)
+
+
+def _load_model(model_name: str, compute_type: str, device: str):
+    """Build a WhisperModel, falling back from CUDA to CPU/int8 if needed."""
+    from faster_whisper import WhisperModel  # imported here so --help works without it
+
+    try:
+        _log(f"loading model '{model_name}' on {device} (compute={compute_type})…")
+        return WhisperModel(model_name, device=device, compute_type=compute_type), device, compute_type
+    except Exception as exc:  # noqa: BLE001 — CUDA/cuDNN errors vary by driver
+        if device == "cuda":
+            _log(f"CUDA load failed ({type(exc).__name__}: {exc}); falling back to CPU/int8")
+            return WhisperModel(model_name, device="cpu", compute_type="int8"), "cpu", "int8"
+        raise
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(prog="whisper_local", description=__doc__)
+    ap.add_argument("audio", help="Path to the audio (or video) file to transcribe")
+    ap.add_argument("--words", action="store_true", help="Emit word-level timestamps")
+    ap.add_argument("--model", default=DEFAULT_MODEL)
+    ap.add_argument("--compute-type", default=DEFAULT_COMPUTE)
+    ap.add_argument("--beam-size", type=int, default=DEFAULT_BEAM)
+    ap.add_argument("--device", default="cuda", choices=["cuda", "cpu"])
+    ap.add_argument(
+        "--language", default=None,
+        help="Force a language code (default: auto-detect)",
+    )
+    ap.add_argument(
+        "--translate", action="store_true",
+        help="Translate non-English audio to English (task=translate)",
+    )
+    args = ap.parse_args()
+
+    model, device_used, compute_used = _load_model(args.model, args.compute_type, args.device)
+    task = "translate" if args.translate else "transcribe"
+
+    _log(f"transcribing (task={task}, beam={args.beam_size}, words={args.words})…")
+    seg_iter, info = model.transcribe(
+        args.audio,
+        task=task,
+        language=args.language,
+        beam_size=args.beam_size,
+        vad_filter=True,
+        word_timestamps=args.words,
+        temperature=0.0,
+        condition_on_previous_text=False,
+    )
+
+    segments: list[dict] = []
+    words: list[dict] = []
+    for seg in seg_iter:  # generator — iterating is what actually runs inference
+        text = (seg.text or "").strip()
+        if text:
+            segments.append({
+                "start": round(float(seg.start or 0.0), 2),
+                "end": round(float(seg.end or 0.0), 2),
+                "text": text,
+            })
+        if args.words and getattr(seg, "words", None):
+            for w in seg.words:
+                wt = (w.word or "").strip()
+                if not wt:
+                    continue
+                words.append({
+                    "word": wt,
+                    "start": round(float(w.start or 0.0), 3),
+                    "end": round(float(w.end or 0.0), 3),
+                })
+
+    _log(f"done — {len(segments)} segments, {len(words)} words, lang={info.language}")
+    json.dump(
+        {
+            "segments": segments,
+            "words": words,
+            "language": info.language,
+            "model": args.model,
+            "device": device_used,
+            "compute_type": compute_used,
+            "backend": "local-faster-whisper",
+        },
+        sys.stdout,
+    )
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What

Adds an on-machine Whisper backend so `/watch` can transcribe caption-less videos without a Groq/OpenAI API key — the audio never leaves the machine. Captions are still tried first; this only changes the *fallback*. Opt in with `WATCH_WHISPER_LOCAL=1` — when set and a faster-whisper interpreter is resolvable, `local` becomes the default fallback backend.

## How

- **New `scripts/whisper_local.py`** — a small bridge that transcribes one audio file with [faster-whisper](https://github.com/SYSTRAN/faster-whisper) and prints the **same JSON shape** the API backends produce (`{segments: [{start, end, text}], words: [{word, start, end}]}`). Because the shape is identical, frame/transcript alignment and the 0-10s hook microscope work unchanged. Defaults: `large-v3` / `float16` / beam 1 / VAD on; CUDA when available, CPU/int8 fallback.
- **`scripts/whisper.py`** — adds a `local` backend: `_local_python()` resolves the interpreter (explicit `$WATCH_WHISPER_LOCAL_PYTHON`, else the current interpreter if it can import `faster_whisper`), `load_api_key()` returns `("local", "local")` when local mode is on, and `transcribe_video()` / `transcribe_audio()` route to the bridge.
- **`scripts/watch.py`** — `--whisper local` choice.
- **`scripts/setup.py`** — `--check` / `--json` report `ready` with `whisper_backend: local` when local mode is configured, so no API key is requested.
- **Docs** — README capabilities table + a "Local Whisper" section, SKILL.md Transcription section, CHANGELOG 0.3.0.

## Why

faster-whisper (CTranslate2) gives large-v3 quality locally on a consumer GPU. For users who already run a local Whisper setup, or who'd rather not manage an API key / send audio to a third party, this makes `/watch` fully self-hosted for transcription while leaving the existing API backends untouched.

## Notes / tradeoffs

- The interpreter that runs faster-whisper can differ from the skill's own Python (GPU venvs commonly do), hence `$WATCH_WHISPER_LOCAL_PYTHON`. If `faster_whisper` is importable in the skill's own interpreter, that's used automatically.
- The model loads per invocation, so local transcription adds a few seconds of startup vs. an API call.
- No new dependencies on the default (API) path — `faster_whisper` is only imported by the bridge, under the user's chosen interpreter.
- Additive and backwards-compatible; the Groq/OpenAI backends are unchanged.

Tested on Windows + RTX GPU: forced `--whisper local` on a caption-less local file produced both the main transcript and word-level hook timestamps; `setup.py --check` returns 0 with `backend: local`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSmN1aH9GX2g6nCkavaTh5
