### PR TITLE
fix: force UTF-8 stdout/stderr so non-Latin transcripts don't crash on Windows

### DIFF
--- a/scripts/watch.py
+++ b/scripts/watch.py
@@ -12,6 +12,18 @@ import tempfile
 from pathlib import Path
 
 
+# Force UTF-8 on stdout/stderr so non-Latin transcripts (Arabic, emoji, accented
+# text) don't crash the run on Windows, whose console defaults to a legacy
+# codepage (cp1252) that can't encode them. No-op on platforms already using UTF-8.
+for _stream in (sys.stdout, sys.stderr):
+    _reconfigure = getattr(_stream, "reconfigure", None)
+    if _reconfigure is not None:
+        try:
+            _reconfigure(encoding="utf-8", errors="replace")
+        except (ValueError, OSError):
+            pass
+
+
 SCRIPT_DIR = Path(__file__).parent.resolve()
 sys.path.insert(0, str(SCRIPT_DIR))
 


### PR DESCRIPTION
## Problem

On Windows, `scripts/watch.py` crashes at the end of a run whenever the transcript (or video title) contains non-Latin characters — Arabic, emoji, accented text, etc. The Windows console defaults to a legacy codepage (cp1252) that can't encode those characters, so the final `print(transcript_text)` throws:

```
UnicodeEncodeError: 'charmap' codec can't encode characters in position 8-14: character maps to <undefined>
```

The frames and `report.md` are already written to the working directory before the crash, so no data is lost — but the script exits non-zero and stdout is truncated, so the orchestrating agent loses the frame list + transcript that it parses from the script's output. In practice this makes `/watch` fail its normal flow for any non-English video on Windows.

## Fix

Reconfigure `sys.stdout` / `sys.stderr` to UTF-8 at startup:

```python
for _stream in (sys.stdout, sys.stderr):
    _reconfigure = getattr(_stream, "reconfigure", None)
    if _reconfigure is not None:
        try:
            _reconfigure(encoding="utf-8", errors="replace")
        except (ValueError, OSError):
            pass
```

- Guarded with `getattr` + `try/except` so it's a safe no-op on platforms whose streams are already UTF-8 (macOS/Linux) or that lack `reconfigure()`.
- `errors="replace"` means a truly un-encodable byte degrades to `�` rather than crashing.

## Testing

Verified on Windows 11 (PowerShell, default console codepage), Python 3.12:

- **Before:** watching an 18s reel with an Arabic transcript (`اشتركوا في القناة`) crashed with `UnicodeEncodeError` and exit code 1.
- **After:** the same video prints the Arabic transcript correctly and exits 0.

No change in behavior on macOS/Linux (reconfigure to UTF-8 is a no-op there).
