### PR TITLE
fix: survive real-world failures on Windows, ffmpeg 9, and YouTube 403s

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -29,21 +29,32 @@ None of the above add new dependencies — pure ffmpeg + stdlib + the existing W
 Steps 4.4 and 4.5 stage the report inside an Obsidian vault so the user can read it where they read everything else. Resolve the vault directory in this order — first hit wins, and the result is what `$VAULT_DIR` refers to everywhere below:
 
 1. **`$WATCH_VAULT_DIR` env var** — if set and the path exists, use it. This is the user-controlled override.
-2. **`~/Second brain/`** — if it exists as a directory.
-3. **`~/Documents/Obsidian/`** — if it exists as a directory.
-4. **`~/Obsidian/`** — if it exists as a directory.
-5. **None found** — skip Steps 4.4 and 4.5 entirely. Print one line in chat so the user knows what happened: `📄 Report (no vault detected): <workdir>/report.md`. Suggest they set `WATCH_VAULT_DIR` if they want auto-ingest.
+2. **A directory containing a `.obsidian/` folder**, searched one level deep under `~` (and under `~/Documents`). This is the reliable check: an Obsidian vault is *defined* by that marker folder, so detect it instead of guessing at names. Prefer this over the name list below.
+3. **Name fallbacks**, in order: `~/SecondBrain/`, `~/Second brain/`, `~/Second Brain/`, `~/Documents/Obsidian/`, `~/Obsidian/`.
+4. **None found** — skip Steps 4.4 and 4.5 entirely. Print one line in chat so the user knows what happened: `📄 Report (no vault detected): <workdir>/report.md`. Suggest they set `WATCH_VAULT_DIR` if they want auto-ingest.
 
 A quick way to resolve it in bash inside the skill:
 
 ```bash
 VAULT_DIR="${WATCH_VAULT_DIR:-}"
+
+# marker-based detection first - a vault is any dir with .obsidian/ in it
 if [ -z "$VAULT_DIR" ] || [ ! -d "$VAULT_DIR" ]; then
-  for candidate in "$HOME/Second brain" "$HOME/Documents/Obsidian" "$HOME/Obsidian"; do
+  for marker in "$HOME"/*/.obsidian "$HOME"/Documents/*/.obsidian; do
+    [ -d "$marker" ] && { VAULT_DIR="$(dirname "$marker")"; break; }
+  done
+fi
+
+# name fallbacks
+if [ -z "$VAULT_DIR" ] || [ ! -d "$VAULT_DIR" ]; then
+  for candidate in "$HOME/SecondBrain" "$HOME/Second brain" "$HOME/Second Brain" \
+                   "$HOME/Documents/Obsidian" "$HOME/Obsidian"; do
     if [ -d "$candidate" ]; then VAULT_DIR="$candidate"; break; fi
   done
 fi
 ```
+
+⚠️ **Windows:** the `open` command in Step 4.4 is macOS-only. Use `start ""` (cmd) or `explorer.exe` with the `obsidian://` URL, or simply skip the auto-open and just echo the vault-relative path.
 
 The vault's URL-name (for the `obsidian://` URL scheme in Step 4.4) is the final path component — e.g. `$HOME/Second brain` → `Second brain`. URL-encode spaces as `%20`.
 

--- a/scripts/download.py
+++ b/scripts/download.py
@@ -38,6 +38,7 @@ def resolve_local(path: str) -> dict:
         "subtitle_path": None,
         "info": {"title": p.name, "url": str(p)},
         "downloaded": False,
+        "video_error": None,
     }
 
 
@@ -66,7 +67,7 @@ def download_url(url: str, out_dir: Path) -> dict:
     out_dir.mkdir(parents=True, exist_ok=True)
     output_template = str(out_dir / "video.%(ext)s")
 
-    cmd = [
+    base = [
         "yt-dlp",
         "-N", "8",
         "-f", "bv*[height<=720]+ba/b[height<=720]/bv+ba/b",
@@ -80,20 +81,45 @@ def download_url(url: str, out_dir: Path) -> dict:
         "--no-playlist",
         "--ignore-errors",
         "-o", output_template,
-        "--",
-        url,
     ]
 
     # yt-dlp may exit non-zero if a subtitle variant fails (e.g. 429) even when
     # the video itself downloaded fine. Treat "video file present" as success.
-    result = subprocess.run(cmd, stdout=sys.stderr, stderr=sys.stderr)
+    result = subprocess.run(base + ["--", url], stdout=sys.stderr, stderr=sys.stderr)
     video = _pick_video(out_dir)
-    if video is None:
-        raise SystemExit(
-            f"yt-dlp did not produce a video file in {out_dir} (exit {result.returncode})"
-        )
+
+    # YouTube increasingly serves 403 / "confirm you're not a bot" to the default
+    # player client while still handing over subtitles. Retry the stream with
+    # other clients before giving up on frames.
+    if video is None and is_url(url):
+        for client in ("android", "web_safari", "ios", "mweb", "tv_embedded"):
+            print(f"[watch] stream failed; retrying player_client={client}…", file=sys.stderr)
+            subprocess.run(
+                base + ["--extractor-args", f"youtube:player_client={client}", "--", url],
+                stdout=sys.stderr, stderr=sys.stderr,
+            )
+            video = _pick_video(out_dir)
+            if video is not None:
+                print(f"[watch] stream recovered via player_client={client}", file=sys.stderr)
+                break
 
     subtitle = _pick_subtitle(out_dir)
+
+    # Degrade instead of dying: if the stream is unavailable but captions came
+    # through, a transcript-only watch is still worth emitting a report for.
+    video_error = None
+    if video is None:
+        if subtitle is None:
+            raise SystemExit(
+                f"yt-dlp produced neither a video nor subtitles in {out_dir} "
+                f"(exit {result.returncode}). If this is age-gated, private, or "
+                f"bot-checked, pass cookies via yt-dlp --cookies-from-browser."
+            )
+        video_error = (
+            "video stream unavailable (403 / bot-check / DRM) - captions were "
+            "retrieved, continuing transcript-only with no frames"
+        )
+        print(f"[watch] WARNING: {video_error}", file=sys.stderr)
     info_path = out_dir / "video.info.json"
     info: dict = {}
     if info_path.exists():
@@ -110,10 +136,11 @@ def download_url(url: str, out_dir: Path) -> dict:
             info = {"url": url}
 
     return {
-        "video_path": str(video),
+        "video_path": str(video) if video else None,
         "subtitle_path": str(subtitle) if subtitle else None,
         "info": info or {"url": url},
         "downloaded": True,
+        "video_error": video_error,
     }
 
 

--- a/scripts/frames.py
+++ b/scripts/frames.py
@@ -227,18 +227,28 @@ def extract_scene_change(
         cmd += ["-ss", f"{start_seconds:.3f}"]
     if end_seconds is not None:
         cmd += ["-to", f"{end_seconds:.3f}"]
-    cmd += [
-        "-i", str(Path(video_path).resolve()),
-        "-vf", vf,
-        "-vsync", "vfr",
-        "-frames:v", str(max_frames),
-        "-q:v", "4",
-        output_pattern,
-    ]
+    # NOTE: the pacing flag is an OUTPUT option - it must come after -i/-vf,
+    # otherwise ffmpeg rejects it as an input option applied to the input file.
+    head = cmd + ["-i", str(Path(video_path).resolve()), "-vf", vf]
+    tail = ["-frames:v", str(max_frames), "-q:v", "4", output_pattern]
 
-    result = subprocess.run(cmd, capture_output=True, text=True)
-    if result.returncode != 0:
-        raise SystemExit(f"ffmpeg scene-change extraction failed: {result.stderr.strip()}")
+    # Variable frame rate is required so scene-change picks emit one frame each.
+    # ffmpeg 7+ removed `-vsync` in favour of `-fps_mode`; older builds only
+    # know `-vsync`. Try the modern spelling first and fall back on the old one.
+    result = None
+    for pacing_flag in (["-fps_mode", "vfr"], ["-vsync", "vfr"]):
+        result = subprocess.run(head + pacing_flag + tail, capture_output=True, text=True)
+        if result.returncode == 0:
+            break
+        err = (result.stderr or "").lower()
+        if "unrecognized option" not in err and "option not found" not in err:
+            break  # a real failure, not a flag-compatibility problem
+
+    if result is None or result.returncode != 0:
+        raise SystemExit(
+            f"ffmpeg scene-change extraction failed: "
+            f"{(result.stderr or '').strip() if result else 'no result'}"
+        )
 
     # Parse pts_time lines from stdout/stderr (ffmpeg version variance).
     pts_times: list[float] = []

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -57,11 +57,25 @@ def _check_binaries() -> list[str]:
     return [b for b in REQUIRED_BINARIES if not _which(b)]
 
 
+_PERM_WARNED = False
+
+
 def _check_file_permissions(path: Path) -> None:
-    """Warn to stderr if a secrets file is world/group readable."""
+    """Warn to stderr if a secrets file is world/group readable.
+
+    No-op on Windows: NTFS ACLs don't map onto the POSIX mode bits, and
+    os.stat() reports 0o666 for every ordinary file, so the check fires
+    unconditionally and the advice (`chmod 600`) does nothing there.
+    """
+    global _PERM_WARNED
+    if os.name == "nt":
+        return
+    if _PERM_WARNED:
+        return
     try:
         mode = path.stat().st_mode
         if mode & 0o044:
+            _PERM_WARNED = True  # once per process, not once per key lookup
             sys.stderr.write(
                 f"[watch] WARNING: {path} is readable by other users. "
                 f"Run: chmod 600 {path}\n"
@@ -71,6 +85,26 @@ def _check_file_permissions(path: Path) -> None:
         pass
 
 
+def _read_config_text(path: Path) -> str | None:
+    """Read the .env tolerantly.
+
+    Editors on Windows write cp1252 (an em-dash in a comment is 0x97), which
+    made a strict utf-8 read raise UnicodeDecodeError. That is not an OSError,
+    so it escaped the caller's handler and crashed the whole preflight.
+    """
+    for encoding in ("utf-8", "utf-8-sig", "cp1252", "latin-1"):
+        try:
+            return path.read_text(encoding=encoding)
+        except UnicodeDecodeError:
+            continue
+        except OSError:
+            return None
+    try:
+        return path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+
+
 def _read_env_key(name: str) -> str | None:
     value = os.environ.get(name)
     if value and value.strip():
@@ -78,20 +112,20 @@ def _read_env_key(name: str) -> str | None:
     if not CONFIG_FILE.exists():
         return None
     _check_file_permissions(CONFIG_FILE)
-    try:
-        for line in CONFIG_FILE.read_text(encoding="utf-8").splitlines():
-            line = line.strip()
-            if not line or line.startswith("#") or "=" not in line:
-                continue
-            key, _, raw = line.partition("=")
-            if key.strip() != name:
-                continue
-            raw = raw.strip()
-            if len(raw) >= 2 and raw[0] in ('"', "'") and raw[-1] == raw[0]:
-                raw = raw[1:-1]
-            return raw or None
-    except OSError:
+    text = _read_config_text(CONFIG_FILE)
+    if text is None:
         return None
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, raw = line.partition("=")
+        if key.strip() != name:
+            continue
+        raw = raw.strip()
+        if len(raw) >= 2 and raw[0] in ('"', "'") and raw[-1] == raw[0]:
+            raw = raw[1:-1]
+        return raw or None
     return None
 
 

--- a/scripts/watch.py
+++ b/scripts/watch.py
@@ -84,8 +84,16 @@ def main() -> int:
     dl = download(args.source, work / "download")
     video_path = dl["video_path"]
 
-    meta = get_metadata(video_path)
-    full_duration = meta["duration_seconds"]
+    # Transcript-only mode: the stream was unavailable (403 / bot-check / DRM)
+    # but captions came through. Everything that needs the video file is skipped
+    # and we still emit a report rather than losing the whole run.
+    transcript_only = video_path is None
+    if transcript_only:
+        meta = {"duration_seconds": float(dl.get("info", {}).get("duration") or 0.0)}
+        full_duration = meta["duration_seconds"]
+    else:
+        meta = get_metadata(video_path)
+        full_duration = meta["duration_seconds"]
 
     start_sec = parse_time(args.start)
     end_sec = parse_time(args.end)
@@ -117,7 +125,10 @@ def main() -> int:
     print(f"[watch] extracting ~{target} frames at {fps:.3f} fps over {scope}…", file=sys.stderr)
 
     use_scene = (not args.no_scene_change) and not focused and args.fps is None
-    if use_scene:
+    if transcript_only:
+        frames = []
+        sampling_mode = "none (no video stream)"
+    elif use_scene:
         print("[watch] extracting scene-change frames (one per shot)…", file=sys.stderr)
         frames = extract_scene_change(
             video_path,
@@ -157,7 +168,7 @@ def main() -> int:
     )
 
     # Hook microscope: dense pass over [0, 10s] when not in focused mode.
-    if (not args.no_hook_microscope) and (not focused) and full_duration >= 30.0:
+    if (not args.no_hook_microscope) and (not focused) and (not transcript_only) and full_duration >= 30.0:
         print("[watch] running hook microscope on first 10s…", file=sys.stderr)
         hook_backend, hook_key = (None, None)
         if not args.no_whisper:
@@ -183,7 +194,13 @@ def main() -> int:
         except Exception as exc:
             print(f"[watch] subtitle parse failed: {exc}", file=sys.stderr)
 
-    if not transcript_segments and not args.no_whisper:
+    if not transcript_segments and not args.no_whisper and transcript_only:
+        print(
+            "[watch] no captions and no video stream - Whisper needs the audio track, "
+            "so no transcript is possible for this source",
+            file=sys.stderr,
+        )
+    elif not transcript_segments and not args.no_whisper:
         backend, api_key = load_api_key(args.whisper)
         if backend and api_key:
             try:
@@ -232,6 +249,8 @@ def main() -> int:
     print("# watch: video report")
     print()
     print(f"- **Source:** {args.source}")
+    if dl.get("video_error"):
+        print(f"- **⚠️ Degraded:** {dl['video_error']}")
     if info.get("title"):
         print(f"- **Title:** {info['title']}")
     if info.get("uploader"):


### PR DESCRIPTION
Five bugs that made `/watch` fail on a stock Windows machine. Each was found by an actual failed run, not by reading the code, and each fix was re-tested against the exact failure that exposed it.

## `setup.py` — preflight crashed outright

`_read_env_key` read `~/.config/watch/.env` with strict utf-8. A Windows editor had written an em-dash in a **comment** as cp1252 `0x97`, so the read raised `UnicodeDecodeError` — which is not an `OSError`, so it escaped the `except OSError` around it and took down the whole preflight with a traceback.

Now tries utf-8 → utf-8-sig → cp1252 → latin-1, then a lossy read. *Verified by reproducing the exact byte at offset 64: traceback before, clean parse after.*

## `setup.py` — permanent false "world-readable" warning

`mode & 0o044` fires unconditionally on Windows, where `os.stat()` reports `0o666` for every ordinary file and the suggested remedy (`chmod 600`) does nothing on NTFS. It also printed once per key lookup — three times per run.

Skipped on `os.name == "nt"`, and rate-limited to once per process.

## `download.py` — a failed video stream threw away a good transcript

If yt-dlp got the subtitles but not the stream, `download_url` raised `SystemExit` and the entire run died. The captions were already on disk and no `report.md` was ever emitted.

Now returns `video_path=None` plus a `video_error` string, and only aborts when **neither** video nor subtitles were obtained.

## `download.py` — no retry on YouTube's bot-check

YouTube increasingly serves `403` / "Sign in to confirm you're not a bot" to the default player client while still handing over subtitles.

Added a fallback chain: `android`, `web_safari`, `ios`, `mweb`, `tv_embedded`. *Verified live — the default client 403'd, `player_client=android` recovered the stream.*

## `watch.py` — transcript-only mode

Handles `video_path=None` by skipping ffprobe metadata, frame extraction, the hook microscope, and the Whisper fallback (which needs the audio track), while still writing `report.md`. The degradation is surfaced in the printed report.

## `frames.py` — scene-change extraction broken on ffmpeg 7+

ffmpeg 7 removed `-vsync`. On ffmpeg 9 **every** scene-change run failed with `Unrecognized option 'vsync'`, so the feature was dead on any modern install, on every platform.

Now tries `-fps_mode vfr` and falls back to `-vsync vfr` only on a flag-compatibility error. The pacing flag has to stay an **output** option (after `-i`/`-vf`) — putting it before the input makes ffmpeg reject it as an input option.

## `SKILL.md` — vault detection couldn't find real vaults

Only matched `~/Second brain`, `~/Documents/Obsidian`, `~/Obsidian`, so a vault named e.g. `SecondBrain` was never detected and Steps 4.4/4.5 silently skipped.

Now detects any directory containing a `.obsidian/` marker one level under `~` or `~/Documents` — that folder is what actually *defines* a vault — with the name list kept as fallback. Also noted that Step 4.4's `open` is macOS-only.

## Testing

Full clean run after the fixes: download → 10 frames → `report.md` with pending markers intact. All nine scripts byte-compile. `SKILL.md` references a `tests/` directory that doesn't exist in the repo, so there was no suite to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
